### PR TITLE
mark dependencies as unique

### DIFF
--- a/local-schema.json
+++ b/local-schema.json
@@ -158,7 +158,8 @@
               {
                 "type": "array",
                 "items": {
-                  "type": "string"
+                  "type": "string",
+                  "uniqueItems": true
                 }
               }
             ],


### PR DESCRIPTION
This didn't go as far as I hoped. JSON Schema has no way to express "make sure this array of objects has a property whose value is unique", which is what we would need to address #17.