### PR TITLE
Fix schema association to match files with no extension. Makes it work for unsaved files.

### DIFF
--- a/src/schema-association-service.ts
+++ b/src/schema-association-service.ts
@@ -22,7 +22,6 @@ export class SchemaAssociationService implements ISchemaAssociationService {
     }
 
     public getSchemaAssociation(): ISchemaAssociations {
-        //return { '*.*': [this.schemaFilePath] };
         return { '*': [this.schemaFilePath] };
     }
 }


### PR DESCRIPTION
This resolves https://github.com/Microsoft/azure-pipelines-vscode/issues/97