### PR TITLE
remove the preLaunchTask when debugging the extension

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -15,8 +15,7 @@
             ],
             "outFiles": [
                 "${workspaceFolder}/out/**/*.js"
-            ],
-            "preLaunchTask": "npm: watch"
+            ]
         },
         {
             "name": "Extension Tests",
@@ -30,8 +29,7 @@
             ],
             "outFiles": [
                 "${workspaceFolder}/out/test/**/*.js"
-            ],
-            "preLaunchTask": "npm: watch"
+            ]
         },
         {
             "name": "Extension Tests From Server",
@@ -45,8 +43,7 @@
             ],
             "outFiles": [
                 "${workspaceFolder}/out/testfromserver/**/*.js"
-            ],
-            "preLaunchTask": "npm: watch"
+            ]
         }
     ]
 }


### PR DESCRIPTION
I had trouble launching the extension in debug mode because VS Code seemed to be waiting for npm watch to terminate which it obviously never would.