### PR TITLE
do not generate validiation errors for 'empty' files

### DIFF
--- a/local-schema.json
+++ b/local-schema.json
@@ -4,7 +4,15 @@
   "$comment": "v1.140.3",
   "title": "Pipeline schema",
   "description": "A pipeline definition",
-  "$ref": "#/definitions/pipeline",
+  "oneOf": [
+    {
+      "$ref": "#/definitions/pipeline"
+    },
+    {
+      "type": "string",
+      "pattern": "^$"
+    }
+  ],
   "definitions": {
     "pipeline": {
       "type": "object",

--- a/src/schemata.ts
+++ b/src/schemata.ts
@@ -484,7 +484,16 @@ export const schema140: string = JSON.stringify({
     "$comment": "v1.140.3",
     "title": "Pipeline schema",
     "description": "A pipeline definition",
-    "$ref": "#/definitions/pipeline",
+    "oneOf": [
+      {
+        "$ref": "#/definitions/pipeline"
+      },
+      {
+        //allow an empty file
+        "type": "string",
+        "pattern": "^$"
+      }
+    ],
     "definitions": {
       "pipeline": {
         "type": "object",


### PR DESCRIPTION
do not generate validiation errors for 'empty' files that contain whitespace or comments

Addresses #155 

This fix depends on https://github.com/Microsoft/azure-pipelines-language-server/pull/30 which will be included in version 0.4.1 of the language-service when it is published.