### PR TITLE
fix a build issue by changing the npm cache directory

### DIFF
--- a/.azure-pipelines/release-pipeline.yml
+++ b/.azure-pipelines/release-pipeline.yml
@@ -31,7 +31,7 @@ steps:
 
 # create a GitHub Release
 - bash: |
-    npm config set cache $(Build.SourcesDirectory)/.azure-pipelines/github-release/npm-cache --global
+    export npm_config_cache=$(Build.SourcesDirectory)/.azure-pipelines/github-release/npm-cache
     npm install
   displayName: Prepare to create GitHub Release
   workingDirectory: '$(Build.SourcesDirectory)/.azure-pipelines/github-release'

--- a/.azure-pipelines/release-pipeline.yml
+++ b/.azure-pipelines/release-pipeline.yml
@@ -30,7 +30,9 @@ steps:
   displayName: Check for length of mini-changelog
 
 # create a GitHub Release
-- bash: npm install
+- bash: |
+    npm config set cache $(Build.SourcesDirectory)/.azure-pipelines/github-release/npm-cache --global
+    npm install
   displayName: Prepare to create GitHub Release
   workingDirectory: '$(Build.SourcesDirectory)/.azure-pipelines/github-release'
 - bash: |


### PR DESCRIPTION
Builds started getting this error:

Unhandled rejection Error: EACCES: permission denied, mkdir '/home/vsts/.npm/_cacache/index-v5/72/f2'
npm ERR! cb() never called!

I'm not sure if it was a change on the build machine to block the home directory or a change in npm's behavior.  Either way, moving the cache directory fixes it.