### PR TITLE
Telemetry and User input sequence changes with bug fixes

### DIFF
--- a/src/configure/activate.ts
+++ b/src/configure/activate.ts
@@ -5,7 +5,7 @@ import { AzureExtensionApi, AzureExtensionApiProvider } from 'vscode-azureextens
 import { configurePipeline } from './configure';
 import { Messages } from './resources/messages';
 import { AzureAccountExtensionExports, extensionVariables } from './model/models';
-import { TelemetryHelper } from './helper/telemetryHelper';
+import { telemetryHelper } from './helper/telemetryHelper';
 
 export async function activateConfigurePipeline(): Promise<AzureExtensionApiProvider> {
     let azureAccountExtension = vscode.extensions.getExtension("ms-vscode.azure-account");
@@ -24,8 +24,8 @@ export async function activateConfigurePipeline(): Promise<AzureExtensionApiProv
     // The commandId parameter must match the command field in package.json
     registerCommand('configure-pipeline', async (actionContext: IActionContext, node: any) => {
         // The code you place here will be executed every time your command is executed
-        let telemetryHelper = new TelemetryHelper(actionContext, 'configure');
-        await configurePipeline(telemetryHelper, node);
+        telemetryHelper.initialize(actionContext, 'configure-pipeline');
+        await configurePipeline(node);
     });
 
     return createApiProvider([<AzureExtensionApi>

--- a/src/configure/clients/devOps/azureDevOpsClient.ts
+++ b/src/configure/clients/devOps/azureDevOpsClient.ts
@@ -5,6 +5,7 @@ import { AzureDevOpsBaseUrl, ReservedHostNames } from '../../resources/constants
 import { RestClient } from '../restClient';
 import { ServiceClientCredentials, UrlBasedRequestPrepareOptions } from 'ms-rest';
 import { sleepForMilliSeconds, stringCompareFunction } from "../../helper/commonHelper";
+import { telemetryHelper } from '../../helper/telemetryHelper';
 import * as Q from 'q';
 import * as util from 'util';
 
@@ -18,11 +19,12 @@ export class AzureDevOpsClient {
     }
 
     public async sendRequest(urlBasedRequestPrepareOptions: UrlBasedRequestPrepareOptions): Promise<any> {
+        urlBasedRequestPrepareOptions.headers['X-TFS-Session'] = telemetryHelper.getJourneyId();
         return this.restClient.sendRequest(urlBasedRequestPrepareOptions);
     }
 
     public async createOrganization(organizationName: string): Promise<any> {
-        return this.restClient.sendRequest<any>(<UrlBasedRequestPrepareOptions>{
+        return this.sendRequest(<UrlBasedRequestPrepareOptions>{
             url: "https://app.vsaex.visualstudio.com/_apis/HostAcquisition/collections",
             headers: {
                 "Content-Type": "application/json"
@@ -41,7 +43,7 @@ export class AzureDevOpsClient {
     public async createProject(organizationName: string, projectName: string): Promise<any> {
         let collectionUrl = `https://dev.azure.com/${organizationName}`;
 
-        return this.restClient.sendRequest<any>(<UrlBasedRequestPrepareOptions>{
+        return this.sendRequest(<UrlBasedRequestPrepareOptions>{
             url: `${collectionUrl}/_apis/projects`,
             headers: {
                 "Content-Type": "application/json"
@@ -75,7 +77,7 @@ export class AzureDevOpsClient {
         if (!this.listOrgPromise || forceRefresh) {
             this.listOrgPromise = this.getUserData()
             .then((connectionData) => {
-                return this.restClient.sendRequest<any>(<UrlBasedRequestPrepareOptions>{
+                return this.sendRequest(<UrlBasedRequestPrepareOptions>{
                     url: "https://app.vssps.visualstudio.com/_apis/accounts",
                     headers: {
                         "Content-Type": "application/json"
@@ -102,7 +104,7 @@ export class AzureDevOpsClient {
 
     public async listProjects(organizationName: string): Promise<Array<DevOpsProject>> {
         let url = `${AzureDevOpsBaseUrl}/${organizationName}/_apis/projects`;
-        let response = await this.restClient.sendRequest<any>(<UrlBasedRequestPrepareOptions>{
+        let response = await this.sendRequest(<UrlBasedRequestPrepareOptions>{
             url: url,
             headers: {
                 "Content-Type": "application/json"
@@ -128,7 +130,7 @@ export class AzureDevOpsClient {
     public async getRepository(organizationName: string, projectName: string, repositoryName: string): Promise<any> {
         let url = `${AzureDevOpsBaseUrl}/${organizationName}/${projectName}/_apis/git/repositories/${repositoryName}`;
 
-        return this.restClient.sendRequest<any>(<UrlBasedRequestPrepareOptions>{
+        return this.sendRequest(<UrlBasedRequestPrepareOptions>{
             url: url,
             headers: {
                 "Content-Type": "application/json",
@@ -145,7 +147,7 @@ export class AzureDevOpsClient {
     public async createBuildDefinition(organizationName: string, buildDefinition: BuildDefinition): Promise<any> {
         let url = `${AzureDevOpsBaseUrl}/${organizationName}/${buildDefinition.project.id}/_apis/build/definitions`;
 
-        return this.restClient.sendRequest<any>(<UrlBasedRequestPrepareOptions>{
+        return this.sendRequest(<UrlBasedRequestPrepareOptions>{
             url: url,
             method: "POST",
             headers: {
@@ -160,7 +162,7 @@ export class AzureDevOpsClient {
     public async queueBuild(organizationName: string, build: Build): Promise<any> {
         let url = `${AzureDevOpsBaseUrl}/${organizationName}/${build.project.id}/_apis/build/builds`;
 
-        return this.restClient.sendRequest<any>(<UrlBasedRequestPrepareOptions>{
+        return this.sendRequest(<UrlBasedRequestPrepareOptions>{
             url: url,
             method: "POST",
             headers: {
@@ -185,7 +187,7 @@ export class AzureDevOpsClient {
         else {
             let url = `https://app.vsaex.visualstudio.com/_apis/HostAcquisition/NameAvailability/${organizationName}`;
 
-            this.restClient.sendRequest<any>(<UrlBasedRequestPrepareOptions>{
+            this.sendRequest(<UrlBasedRequestPrepareOptions>{
                 url: url,
                 headers: {
                     "Content-Type": "application/json",
@@ -211,7 +213,7 @@ export class AzureDevOpsClient {
     public async getProjectIdFromName(organizationName: string, projectName: string): Promise<string> {
         let url = `${AzureDevOpsBaseUrl}/${organizationName}/_apis/projects/${projectName}`;
 
-        return this.restClient.sendRequest<any>(<UrlBasedRequestPrepareOptions>{
+        return this.sendRequest(<UrlBasedRequestPrepareOptions>{
             url: url,
             method: "GET",
             headers: {
@@ -240,7 +242,7 @@ export class AzureDevOpsClient {
     }
 
     private getConnectionData(): Promise<any> {
-        return this.restClient.sendRequest<any>(<UrlBasedRequestPrepareOptions>{
+        return this.sendRequest(<UrlBasedRequestPrepareOptions>{
             url: "https://app.vssps.visualstudio.com/_apis/connectiondata",
             headers: {
                 "Content-Type": "application/json"
@@ -252,7 +254,7 @@ export class AzureDevOpsClient {
     }
 
     private createUserProfile(): Promise<any> {
-        return this.restClient.sendRequest<any>(<UrlBasedRequestPrepareOptions>{
+        return this.sendRequest(<UrlBasedRequestPrepareOptions>{
             url: "https://app.vssps.visualstudio.com/_apis/_AzureProfile/CreateProfile",
             headers: {
                 "Content-Type": "application/json"
@@ -286,7 +288,7 @@ export class AzureDevOpsClient {
     }
 
     private async getOperationResult(operationUrl: string): Promise<any> {
-        return this.restClient.sendRequest<any>(<UrlBasedRequestPrepareOptions>{
+        return this.sendRequest(<UrlBasedRequestPrepareOptions>{
             url: operationUrl,
             queryParameters: {
                 "api-version": "5.0"
@@ -300,7 +302,7 @@ export class AzureDevOpsClient {
     public getAgentQueues(organizationName: string, projectName: string): Promise<Array<any>> {
         let url = `${AzureDevOpsBaseUrl}/${organizationName}/${projectName}/_apis/distributedtask/queues`;
 
-        return this.restClient.sendRequest<any>(<UrlBasedRequestPrepareOptions>{
+        return this.sendRequest(<UrlBasedRequestPrepareOptions>{
             url: url,
             method: "GET",
             headers: {

--- a/src/configure/helper/controlProvider.ts
+++ b/src/configure/helper/controlProvider.ts
@@ -1,30 +1,24 @@
 import { QuickPickItem, InputBoxOptions } from 'vscode';
 import { IAzureQuickPickOptions } from 'vscode-azureextensionui';
+import { telemetryHelper } from '../helper/telemetryHelper'
 import { extensionVariables } from '../model/models';
-import { TelemetryHelper } from './telemetryHelper';
 import { TelemetryKeys } from '../resources/telemetryKeys';
 
 export class ControlProvider {
-    private telemetryHelper: TelemetryHelper;
-
-    public constructor(telemetryHelper) {
-        this.telemetryHelper = telemetryHelper;
-    }
-
-    public async showQuickPick<T extends QuickPickItem>(listItems: T[] | Thenable<T[]>, options: IAzureQuickPickOptions, itemCountTelemetryKey?: string): Promise<T> {
+    public async showQuickPick<T extends QuickPickItem>(listName: string, listItems: T[] | Thenable<T[]>, options: IAzureQuickPickOptions, itemCountTelemetryKey?: string): Promise<T> {
         try {
-            this.telemetryHelper.setTelemetry(TelemetryKeys.CurrentUserInput, options.placeHolder);
+            telemetryHelper.setTelemetry(TelemetryKeys.CurrentUserInput, listName);
             return await extensionVariables.ui.showQuickPick(listItems, options);
         }
         finally {
             if (itemCountTelemetryKey) {
-                this.telemetryHelper.setTelemetry(itemCountTelemetryKey, (await listItems).length.toString());
+                telemetryHelper.setTelemetry(itemCountTelemetryKey, (await listItems).length.toString());
             }
         }
     }
 
-    public async showInputBox(options: InputBoxOptions): Promise<string> {
-        this.telemetryHelper.setTelemetry(TelemetryKeys.CurrentUserInput, options.placeHolder);
+    public async showInputBox(inputName: string, options: InputBoxOptions): Promise<string> {
+        telemetryHelper.setTelemetry(TelemetryKeys.CurrentUserInput, inputName);
         return await extensionVariables.ui.showInputBox(options);
     }
 }

--- a/src/configure/helper/devOps/azureDevOpsHelper.ts
+++ b/src/configure/helper/devOps/azureDevOpsHelper.ts
@@ -131,7 +131,7 @@ export class AzureDevOpsHelper {
             }
         }
 
-        if(queueId) {
+        if(queueId !== null) {
             return queueId;
         }
 

--- a/src/configure/helper/telemetryHelper.ts
+++ b/src/configure/helper/telemetryHelper.ts
@@ -6,27 +6,31 @@ import * as logger from '../../logger';
 
 const uuid = require('uuid/v4');
 
-export class TelemetryHelper {
+class TelemetryHelper {
     private actionContext: IActionContext;
     private telemetryReporter: ITelemetryReporter;
     private journeyId: string;
     private command: string;
-    constructor(actionContext: IActionContext, command: string) {
+
+    public initialize(actionContext: IActionContext, command: string): void {
         this.actionContext = actionContext;
         this.telemetryReporter = extensionVariables.reporter;
         this.journeyId = uuid();
         this.command = command;
-        this.setTelemetry(TelemetryKeys.Command, command);
         this.setTelemetry(TelemetryKeys.JourneyId, this.journeyId);
     }
 
-    public setTelemetry(key: string, value: string) {
+    public getJourneyId(): string {
+        return this.journeyId;
+    }
+
+    public setTelemetry(key: string, value: string): void {
         if (key) {
             this.actionContext.telemetry.properties[key] = value;
         }
     }
 
-    public setResult(result: Result, error?: Error) {
+    public setResult(result: Result, error?: Error): void {
         this.actionContext.telemetry.properties.result = result;
         if (error) {
             let parsedError = parseError(error);
@@ -35,11 +39,11 @@ export class TelemetryHelper {
         }
     }
 
-    public setCurrentStep(stepName: string) {
+    public setCurrentStep(stepName: string) : void{
         this.actionContext.telemetry.properties.cancelStep = stepName;
     }
 
-    public logError(layer: string, tracePoint: string, error: Error) {
+    public logError(layer: string, tracePoint: string, error: Error): void {
         let parsedError = parseError(error);
         this.telemetryReporter.sendTelemetryEvent(
             tracePoint,
@@ -50,10 +54,10 @@ export class TelemetryHelper {
                 'error': JSON.stringify(parsedError)
             });
 
-            logger.log(JSON.stringify(parsedError));
+        logger.log(JSON.stringify(parsedError));
     }
 
-    public logInfo(layer: string, tracePoint: string, info: string) {
+    public logInfo(layer: string, tracePoint: string, info: string): void {
         this.telemetryReporter.sendTelemetryEvent(
             tracePoint,
             {
@@ -64,16 +68,17 @@ export class TelemetryHelper {
             });
     }
 
-    public async execteFunctionWithTimeTelemetry<T>(callback: () => T, telemetryKey: string): Promise<T> {
+    public async executeFunctionWithTimeTelemetry<T>(callback: () => T, telemetryKey: string): Promise<T> {
         let startTime = Date.now();
         try {
             return await callback();
         }
-        finally{
-            this.setTelemetry(telemetryKey, ((Date.now() - startTime)/1000).toString());
+        finally {
+            this.setTelemetry(telemetryKey, ((Date.now() - startTime) / 1000).toString());
         }
     }
 }
+export let telemetryHelper = new TelemetryHelper();
 
 export enum Result {
     'Succeeded' = 'Succeeded',

--- a/src/configure/helper/templateHelper.ts
+++ b/src/configure/helper/templateHelper.ts
@@ -57,31 +57,31 @@ function isNodeRepo(files: string[]): boolean {
 
 const nodeTemplates: Array<PipelineTemplate> = [
     {
-        label: 'Node.js with npm',
+        label: 'Node.js with npm to Windows Web App',
         path: path.join(path.dirname(path.dirname(__dirname)), 'configure/templates/nodejs.yml'),
         language: 'node',
         targetType: TargetResourceType.WindowsWebApp
     },
     {
-        label: 'Node.js with Gulp',
+        label: 'Node.js with Gulp to Windows Web App',
         path: path.join(path.dirname(path.dirname(__dirname)), 'configure/templates/nodejsWithGulp.yml'),
         language: 'node',
         targetType: TargetResourceType.WindowsWebApp
     },
     {
-        label: 'Node.js with Grunt',
+        label: 'Node.js with Grunt to Windows Web App',
         path: path.join(path.dirname(path.dirname(__dirname)), 'configure/templates/nodejsWithGrunt.yml'),
         language: 'node',
         targetType: TargetResourceType.WindowsWebApp
     },
     {
-        label: 'Node.js with Angular',
+        label: 'Node.js with Angular to Windows Web App',
         path: path.join(path.dirname(path.dirname(__dirname)), 'configure/templates/nodejsWithAngular.yml'),
         language: 'node',
         targetType: TargetResourceType.WindowsWebApp
     },
     {
-        label: 'Node.js with Webpack',
+        label: 'Node.js with Webpack to Windows Web App',
         path: path.join(path.dirname(path.dirname(__dirname)), 'configure/templates/nodejsWithWebpack.yml'),
         language: 'node',
         targetType: TargetResourceType.WindowsWebApp
@@ -90,7 +90,7 @@ const nodeTemplates: Array<PipelineTemplate> = [
 
 const simpleWebAppTemplates: Array<PipelineTemplate> = [
     {
-        label: 'Simple web app',
+        label: 'Simple application to Windows Web App',
         path: path.join(path.dirname(path.dirname(__dirname)), 'configure/templates/simpleWebApp.yml'),
         language: 'none',
         targetType: TargetResourceType.WindowsWebApp

--- a/src/configure/model/models.ts
+++ b/src/configure/model/models.ts
@@ -32,6 +32,7 @@ export class WizardInputs {
     targetResource: AzureParameters = new AzureParameters();
     pipelineParameters: PipelineParameters = new PipelineParameters();
     azureSession: AzureSession;
+    githubPATToken?: string;
 }
 
 export interface DevOpsProject {
@@ -129,4 +130,9 @@ export interface AadApplication {
     appId: string;
     secret: string;
     objectId: string;
+}
+
+export interface GitBranchDetails {
+    remoteName: string;
+    branch: string;
 }

--- a/src/configure/resources/constants.ts
+++ b/src/configure/resources/constants.ts
@@ -132,3 +132,14 @@ export const ReservedHostNames: string[] = [
     "java",
     "beta"
 ];
+
+export const SelectFolderOrRepository = 'selectFolderOrRepository';
+export const SelectOrganization = 'selectOrganization';
+export const SelectProject = 'selectProject';
+export const EnterOrganizationName = 'enterOrganizationName';
+export const SelectPipelineTemplate = 'selectPipelineTemplate';
+export const SelectSubscription = 'selectSubscription';
+export const SelectWebApp = 'selectWebApp';
+export const GitHubPat = 'gitHubPat';
+export const SelectFromMultipleWorkSpace = 'selectFromMultipleWorkSpace';
+export const SelectRemoteForRepo = 'selectRemoteForRepo';

--- a/src/configure/resources/messages.ts
+++ b/src/configure/resources/messages.ts
@@ -5,7 +5,7 @@ export class Messages {
     public static appKindIsNotSupported: string = 'App of kind: %s is not yet supported.';
     public static azureAccountExntesionUnavailable: string = 'Azure-Account extension could not be fetched. Kindly check it is installed and activated.';
     public static azureLoginRequired: string = 'Kindly sign in to your Azure Account before going forward.';
-    public static branchRemoteMissing: string = `The branch: %s does not have any tracking branch and the selected repository has no remotes. Hence, we are unable to create a remote tracking branch. Kindly, [set a remote tracking branch](https://git-scm.com/docs/git-branch#Documentation/git-branch.txt---track) to procceed.`;
+    public static branchRemoteMissing: string = `The current branch does not have a remote tracking branch and the selected repository has no remotes. Kindly, [set a remote tracking branch](https://git-scm.com/docs/git-branch#Documentation/git-branch.txt---track) with [Azure Repos](https://docs.microsoft.com/en-us/azure/devops/repos/get-started) or [Github](https://guides.github.com/activities/hello-world/) to procceed.`;
     public static browsePipeline: string = 'Browse Pipeline';
     public static cannotAddFileRemoteMissing: string = 'Cannot add yml file to your git repository, remote is not set';
     public static cannotIdentifyRespositoryDetails: string = 'Could not identify repository details. Ensure your git repo is managed with [Azure Repos](https://docs.microsoft.com/en-us/azure/devops/repos/get-started) or [Github](https://guides.github.com/activities/hello-world/)';
@@ -30,11 +30,10 @@ export class Messages {
     public static operationTimedOut: string = 'Operation timed out.';
     public static organizationNameReservedMessage: string = 'The organization name %s is not available. Please try another organization name';
     public static organizationNameStaticValidationMessage: string = 'Organization names must start and end with a letter or number and can contain only letters, numbers, and hyphens';
-    public static pipelineSetupSuccessfully: string = 'Azure DevOps pipelines set up successfully !';
+    public static pipelineSetupSuccessfully: string = 'Azure DevOps pipeline set up successfully !';
     public static remoteRepositoryNotConfigured: string = 'Remote repository is not configured. Manage your git repository with [Azure Repos](https://docs.microsoft.com/en-us/azure/devops/repos/get-started) or [Github](https://guides.github.com/activities/hello-world/)';
     public static resourceIdMissing: string = 'Required argument: resourceId, is missing. Kindly pass the argument for getting resource.';
     public static resourceTypeIsNotSupported: string = 'Resource of type: %s is not yet supported for configuring pipelines.';
-    public static selectFolderOrRepository: string = 'Select the folder or repository to deploy';
     public static selectLabel: string = 'Select';
     public static selectOrganization: string = 'Select Azure DevOps Organization';
     public static selectPathToAppSourceCode: string = 'Select the path to your application source code.';
@@ -43,6 +42,7 @@ export class Messages {
     public static selectRemoteForBranch: string = 'Select the remote repository where you want to track your current branch';
     public static selectSubscription: string = 'Select Azure Subscription';
     public static selectWebApp: string = 'Select Web App';
+    public static selectWorkspaceFolder: string = 'Select a folder from your workspace to deploy';
     public static signInLabel: string = 'Sign In';
     public static unableToCreateAzureServiceConnection: string = `Unable to create azure service connection.\nOperation Status: %s\nMessage: %s\nService connection is not in ready state.`;
     public static unableToCreateGitHubServiceConnection: string =`Unable to create azure service connection.\nOperation Status: %s\nService connection is not in ready state.`;

--- a/src/configure/resources/telemetryKeys.ts
+++ b/src/configure/resources/telemetryKeys.ts
@@ -10,6 +10,7 @@ export class TelemetryKeys {
     public static ChosenTemplate: string = 'chosenTemplate';
     public static PipelineDiscarded: string = 'pipelineDiscarded';
     public static BrowsePipelineClicked: string = 'browsePipelineClicked';
+    public static MultipleWorkspaceFolders: string = 'multipleWorkspaceFolders';
 
     // Durations
     public static ExtensionActivationDuration = 'extensionActivationDuration';

--- a/src/configure/resources/telemetryKeys.ts
+++ b/src/configure/resources/telemetryKeys.ts
@@ -1,6 +1,4 @@
 export class TelemetryKeys {
-    public static Command: string = 'command';
-    public static UserId: string = 'userId';
     public static CurrentUserInput: string = 'currentUserInput';
     public static RepoProvider: string = 'repoProvider';
     public static AzureLoginRequired: string = 'azureLoginRequired';


### PR DESCRIPTION
Changes involves:
1. Linked VSCode Telemetry with Azure DevOps telemetry by setting VsCode JourneyId as UniqueIdentifier in Azure DevOps.
2. Changed the sequence of User Inputs by asking GitHub PAT token earlier along with other repo inputs.
3. Auto detected repo if only workspace is opened and using that to configure pipeline.
4. Telemetry helper changed to single instance
5. More telemetry added
6. Removed logging UserId 