### PR TITLE
AzureKeyVault@1 secrets filter takes a string, not an enum.

### DIFF
--- a/service-schema.json
+++ b/service-schema.json
@@ -8579,11 +8579,10 @@
 									"ignoreCase": "key"
 								},
 								"SecretsFilter": {
+									"type": "string",
 									"description": "Secrets filter",
-									"ignoreCase": "all",
-									"enum": [
-										"EditableOptions"
-									]
+									"ignoreCase": "key",
+									"pattern": "^[A-Za-z0-9-]*$"
 								}
 							},
 							"additionalProperties": false,


### PR DESCRIPTION
See https://github.com/microsoft/azure-pipelines-tasks/blob/1ce4d23fadc246ec4474baa1580e7c58ce35077c/Tasks/AzureKeyVaultV1/task.json#L46

Using enum causes Visual Studio Code, using the Azure Pipelines plugin, to raise a syntax error on JSON using this task in a pipeline.

![image](https://user-images.githubusercontent.com/49630705/71704587-4c7fb580-2e2f-11ea-80b2-2759ac61455d.png)
