### PR TITLE
Prevented erroneous Azure Pipelines schema change notification

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "azure-pipelines",
     "displayName": "Azure Pipelines",
     "description": "Syntax highlighting, IntelliSense, and more for Azure Pipelines YAML",
-    "version": "1.170.0",
+    "version": "1.170.1",
     "publisher": "ms-azure-devops",
     "aiKey": "AIF-d9b70cd4-b9f9-4d70-929b-a071c400b217",
     "repository": {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -93,7 +93,7 @@ async function activateYmlContributor(context: vscode.ExtensionContext) {
     vscode.workspace.onDidChangeConfiguration(e => {
         schemaAssociationService.locateSchemaFile();
         const newSchema = schemaAssociationService.getSchemaAssociation();
-        if (newSchema != initialSchemaAssociations)
+        if (newSchema['*'][0] != initialSchemaAssociations['*'][0])
         {
             vscode.window.showInformationMessage("Azure Pipelines schema changed. Restart VS Code to see the changes.");
             // this _should_ cause the language server to refresh its config


### PR DESCRIPTION
Fix for issue #328: "Azure Pipelines schema changed. Restart VS Code to see the changes." window.

Prior to this fix, whenever you updated _any_ settings, a notification popped up reporting that the Azure Pipelines schema had changed.  This occurred because it was doing an object comparison rather than a string comparison, and a new object was generated every time.  This change retrieves and compares the old and new schema path values.