### PR TITLE
Update recommended TSLint extension

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -2,6 +2,6 @@
 	// See http://go.microsoft.com/fwlink/?LinkId=827846
 	// for the documentation about the extensions.json format
 	"recommendations": [
-		"eg2.tslint"
+		"ms-vscode.vscode-typescript-tslint-plugin"
 	]
 }


### PR DESCRIPTION
The recommended TSLint VS Code extension for this repo is deprecated
#336 