### PR TITLE
Improve activation time

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,9 @@
         "CI/CD"
     ],
     "activationEvents": [
-        "*"
+        "onLanguage:azure-pipelines",
+        "onCommand:configure-pipeline",
+        "onCommand:browse-pipeline"
     ],
     "main": "./out/extension",
     "contributes": {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -8,7 +8,6 @@ import * as vscode from 'vscode';
 import { createTelemetryReporter, callWithTelemetryAndErrorHandling, IActionContext, AzureUserInput, registerUIExtensionVariables } from 'vscode-azureextensionui';
 import * as languageclient from 'vscode-languageclient';
 
-import { activateConfigurePipeline } from './configure/activate';
 import { extensionVariables } from './configure/model/models';
 import * as logger from './logger';
 import { SchemaAssociationService, SchemaAssociationNotification } from './schema-association-service';
@@ -16,12 +15,11 @@ import { schemaContributor, CUSTOM_SCHEMA_REQUEST, CUSTOM_CONTENT_REQUEST } from
 import { telemetryHelper } from './configure/helper/telemetryHelper';
 import { TelemetryKeys } from './configure/resources/telemetryKeys';
 
-const configurePipelineEnabled: boolean = vscode.workspace.getConfiguration('[azure-pipelines]', null).get('configure') ? true : false;
-
 export async function activate(context: vscode.ExtensionContext) {
     extensionVariables.reporter = createTelemetryReporter(context);
     registerUiVariables(context);
 
+    const configurePipelineEnabled = vscode.workspace.getConfiguration('[azure-pipelines]').get<boolean>('configure', true);
     await callWithTelemetryAndErrorHandling('azurePipelines.activate', async (activateContext: IActionContext) => {
         activateContext.telemetry.properties.isActivationEvent = 'true';
         telemetryHelper.initialize(activateContext, 'activate');
@@ -30,6 +28,7 @@ export async function activate(context: vscode.ExtensionContext) {
             async () => {
                 await activateYmlContributor(context);
                 if (configurePipelineEnabled) {
+                    const { activateConfigurePipeline } = await import('./configure/activate');
                     await activateConfigurePipeline();
                 }
             },


### PR DESCRIPTION
- The `azure-arm-websites` package (referenced indirectly by `./configure/activate`) seems to take a long time to be imported. To compensate, only import `./configure/activate` if the Configure Pipeline setting is enabled.
- There's two cases when we should get activated: 1) when a pipeline file is opened, or 2) one of our commands is selected. There's no need for us to activate otherwise, so scope `activationEvents` appropriately.

While activation time itself is still sluggish (in the 1000-1500ms range for me), at least we'll no longer block other extensions from loading on startup 😃.

Future areas to look at:
- do we need to await `activateYmlContributor` or `activateConfigurePipeline`? It seems like we can just start those and let them do their thing in the background.
- update vscode-azureextensionui to 0.36.0 to take advantage of lazy-loading. Unfortunately this is a pretty big undertaking as they've made the telemetry reporter private (why does a *UI* package offer telemetry, anyway?).
- going off of the "why does a UI package offer telemetry reporting" and "why does a UI package require telemetry to be setup in order to start" path, if we stop relying on their telemetry methods and use our own wrappers around vscode-extension-telemetry, then we could probably also defer the import of `vscode-azureextensionui`.
- Webpack

Refs #215. There should be a lot less reports now that the extension is loaded on-demand!