### PR TITLE
Yaml schema persistCredentials should be validated as a boolean

### DIFF
--- a/service-schema.json
+++ b/service-schema.json
@@ -1621,7 +1621,7 @@
         },
         "persistCredentials": {
           "description": "Keep credentials available for later use?",
-          "$ref": "#/definitions/string"
+          "$ref": "#/definitions/boolean"
         }
       },
       "additionalProperties": false
@@ -3252,7 +3252,7 @@
             },
             "persistCredentials": {
               "description": "Keep credentials available for later use?",
-              "$ref": "#/definitions/string"
+              "$ref": "#/definitions/boolean"
             },
             "submodules": {
               "description": "Check out Git submodules?",


### PR DESCRIPTION
As per documentation:
https://docs.microsoft.com/en-us/azure/devops/pipelines/yaml-schema?view=azure-devops&tabs=schema%2Cparameter-schema#checkout

The persistCredentials value from the checkout step should validate as a boolean, not a string.