### PR TITLE
Extension's readme (in VSIX) still uses master branch name

### DIFF
--- a/.azure-pipelines/common-steps.yml
+++ b/.azure-pipelines/common-steps.yml
@@ -19,7 +19,7 @@ steps:
 # Acquire the `vsce` tool and use it to package
 - script: |
     sudo npm install -g vsce
-    vsce package
+    vsce package --githubBranch main
   displayName: Create VSIX
 
 - script: |


### PR DESCRIPTION
The README that is rendered for this extension's marketplace listing still links to the `master` branch (which is now 10 commits behind), instead of the `main` branch.  VSCE has added a `--githubBranch` parameter to let you override its default choice (`master`), and we should pick that up here.

https://code.visualstudio.com/api/working-with-extensions/publishing-extension#marketplace-integration