### PR TITLE
Better debugging story

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -23,7 +23,7 @@
             "request": "launch",
             "runtimeExecutable": "${execPath}",
             "args": [
-                "${workspaceRoot}/src/test/workspace/",
+                "${workspaceFolder}/src/test/workspace/",
                 "--extensionDevelopmentPath=${workspaceFolder}",
                 "--extensionTestsPath=${workspaceFolder}/out/test"
             ],
@@ -37,7 +37,7 @@
             "request": "launch",
             "runtimeExecutable": "${execPath}",
             "args": [
-                "${workspaceRoot}/examples/",
+                "${workspaceFolder}/examples/",
                 "--extensionDevelopmentPath=${workspaceFolder}",
                 "--extensionTestsPath=${workspaceFolder}/out/testfromserver"
             ],

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -52,7 +52,8 @@
             "port": 6009,
             "restart": true,
             "outFiles": [
-                "${workspaceRoot}/node_modules/azure-pipelines-language-server/**/*.js"
+                "${workspaceFolder}/../azure-pipelines-language-server/language-server/out/**/*.js",
+                "${workspaceFolder}/../azure-pipelines-language-server/language-service/lib/**/*.js"
             ]
         }
     ]

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -56,5 +56,14 @@
                 "${workspaceFolder}/../azure-pipelines-language-server/language-service/lib/**/*.js"
             ]
         }
+    ],
+    "compounds": [
+        {
+            "name": "Launch Extension & Attach to Server",
+            "configurations": [
+                "Extension",
+                "Attach to Server"
+            ]
+        }
     ]
 }

--- a/README.md
+++ b/README.md
@@ -79,11 +79,12 @@ If you are only working on the extension (i.e. syntax highlighting, configure pi
 If you are also working on the language server:
 - Follow the first two steps above
 - Clone the [azure-pipelines-language-server](https://github.com/microsoft/azure-pipelines-language-server) repository alongside this repository
-- Follow the instructions in the README to link the language service to the language server
-- In this repository, run `npm link ../azure-pipelines-language-server/language-server`
+- Run `npm link ../azure-pipelines-language-server/language-server`
+- Follow the instructions in the language server README to link the language service to the language server
 - Add the `azure-pipelines-language-server` folder to your VS Code workspace
 - Run the "Launch Extension & Attach to Server" debug configuration
-    - Note: In order to attach correctly, the extension must be activated (in other words, make sure you are editing an Azure Pipelines file)
+    - Note: In order to attach to the server, the extension must be activated (in other words, make sure you are editing an Azure Pipelines file)
+    - In case the attach request timeouts before the server can start, wait for it to start and then run the "Attach to Server" debug configuration
 
 # Contributing
 

--- a/README.md
+++ b/README.md
@@ -69,6 +69,22 @@ VS Code collects usage data and sends it to Microsoft to help improve our produc
 
 - **Failed to determine Azure Repo details from remote url**: If you're configuring a pipeline for a Git repository backed by Azure Repos, ensure that it has a remote pointing to a valid Azure Repos Git repo URL.
 
+## Extension Development
+
+If you are only working on the extension (i.e. syntax highlighting, configure pipeline, and the language client):
+- Run `npm install` to install all necessary dependencies
+- Run `npm run watch` to automatically rebuild the extension whenever you make changes
+- Run the "Extension" debug configuration to launch a VS Code window using your modified version of the extension
+
+If you are also working on the language server:
+- Follow the first two steps above
+- Clone the [azure-pipelines-language-server](https://github.com/microsoft/azure-pipelines-language-server) repository alongside this repository
+- Follow the instructions in the README to link the language service to the language server
+- In this repository, run `npm link ../azure-pipelines-language-server/language-server`
+- Add the `azure-pipelines-language-server` folder to your VS Code workspace
+- Run the "Launch Extension & Attach to Server" debug configuration
+    - Note: In order to attach correctly, the extension must be activated (in other words, make sure you are editing an Azure Pipelines file)
+
 # Contributing
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) if you want to jump in!

--- a/package-lock.json
+++ b/package-lock.json
@@ -714,11 +714,11 @@
             }
         },
         "azure-pipelines-language-server": {
-            "version": "0.5.10",
-            "resolved": "https://registry.npmjs.org/azure-pipelines-language-server/-/azure-pipelines-language-server-0.5.10.tgz",
-            "integrity": "sha512-OnXnBHn81yZUAeX/mGJyK1xgW2TMIrFfqnGoB0JdeqUtEDygSLU0GPjtWQrZCPdcOyfljgOGlK1CZnqZcvXUDw==",
+            "version": "0.6.0",
+            "resolved": "https://registry.npmjs.org/azure-pipelines-language-server/-/azure-pipelines-language-server-0.6.0.tgz",
+            "integrity": "sha512-f81GPGBxTtVYwMO1x8hG8x33JH+aBDBD79ms7cSI4X4niZa1j9s8nieCUSlaaMb21yL58bpIfHjvytOcJVjvoQ==",
             "requires": {
-                "azure-pipelines-language-service": "0.5.10",
+                "azure-pipelines-language-service": "0.6.0",
                 "request-light": "0.2.3",
                 "vscode-languageserver": "4.1.2",
                 "vscode-languageserver-types": "3.6.1",
@@ -739,9 +739,9 @@
             }
         },
         "azure-pipelines-language-service": {
-            "version": "0.5.10",
-            "resolved": "https://registry.npmjs.org/azure-pipelines-language-service/-/azure-pipelines-language-service-0.5.10.tgz",
-            "integrity": "sha512-d5wD9VLIZWTcSfooQWZJ3qhhNU88Eo++2llUaagOU+9R+o6Z1S2xBzcIjmhOD1w26V2HDqR+xGfuthtQrfHLsQ==",
+            "version": "0.6.0",
+            "resolved": "https://registry.npmjs.org/azure-pipelines-language-service/-/azure-pipelines-language-service-0.6.0.tgz",
+            "integrity": "sha512-pRoxYr7+lyF+f+YQB+9H4HkqgR7lkqwt/iJaA8SUnBHhHbrLN7smN2aMms8LkMvhLcovFmwYTnBbEQelxDQoEg==",
             "requires": {
                 "js-yaml": "3.13.1",
                 "jsonc-parser": "2.0.2",
@@ -5942,9 +5942,9 @@
             }
         },
         "vscode-jsonrpc": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-5.0.1.tgz",
-            "integrity": "sha512-JvONPptw3GAQGXlVV2utDcHx0BiY34FupW/kI6mZ5x06ER5DdPG/tXWMVHjTNULF5uKPOUUD0SaXg5QaubJL0A=="
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-6.0.0.tgz",
+            "integrity": "sha512-wnJA4BnEjOSyFMvjZdpiOwhSq9uDoK8e/kpRJDTaMYzwlkrhG1fwDIZI94CLsLzlCK5cIbMMtFlJlfR57Lavmg=="
         },
         "vscode-languageclient": {
             "version": "5.2.1",
@@ -5986,18 +5986,18 @@
             }
         },
         "vscode-languageserver-protocol": {
-            "version": "3.15.3",
-            "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.15.3.tgz",
-            "integrity": "sha512-zrMuwHOAQRhjDSnflWdJG+O2ztMWss8GqUUB8dXLR/FPenwkiBNkMIJJYfSN6sgskvsF0rHAoBowNQfbyZnnvw==",
+            "version": "3.16.0",
+            "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.16.0.tgz",
+            "integrity": "sha512-sdeUoAawceQdgIfTI+sdcwkiK2KU+2cbEYA0agzM2uqaUy2UpnnGHtWTHVEtS0ES4zHU0eMFRGN+oQgDxlD66A==",
             "requires": {
-                "vscode-jsonrpc": "^5.0.1",
-                "vscode-languageserver-types": "3.15.1"
+                "vscode-jsonrpc": "6.0.0",
+                "vscode-languageserver-types": "3.16.0"
             },
             "dependencies": {
                 "vscode-languageserver-types": {
-                    "version": "3.15.1",
-                    "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.15.1.tgz",
-                    "integrity": "sha512-+a9MPUQrNGRrGU630OGbYVQ+11iOIovjCkqxajPa9w57Sd5ruK8WQNsslzpa0x/QJqC8kRc2DUxWjIFwoNm4ZQ=="
+                    "version": "3.16.0",
+                    "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.16.0.tgz",
+                    "integrity": "sha512-k8luDIWJWyenLc5ToFQQMaSrqCHiLwyKPHKPQZ5zz21vM+vIVUSvsRpcbiECH4WR88K2XZqc4ScRcZ7nk/jbeA=="
                 }
             }
         },

--- a/package.json
+++ b/package.json
@@ -157,7 +157,7 @@
     "dependencies": {
         "azure-arm-resource": "7.3.0",
         "azure-arm-website": "5.7.0",
-        "azure-pipelines-language-server": "0.5.10",
+        "azure-pipelines-language-server": "0.6.0",
         "mustache": "3.0.1",
         "q": "1.5.1",
         "shelljs": "^0.3.0",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -103,7 +103,7 @@ async function activateYmlContributor(context: vscode.ExtensionContext) {
 }
 
 function getServerOptions(context: vscode.ExtensionContext): languageclient.ServerOptions {
-    const languageServerPath = context.asAbsolutePath(path.join('node_modules', 'azure-pipelines-language-server', 'server.js'));
+    const languageServerPath = context.asAbsolutePath(path.join('node_modules', 'azure-pipelines-language-server', 'out', 'server.js'));
 
     return {
         run: { module: languageServerPath, transport: languageclient.TransportKind.ipc },


### PR DESCRIPTION
As mentioned in #368. Took me the better half of the day, but I finally got everything working.

- Tell VS Code to look for the sourcemaps in the azure-pipelines-language-server folder
- Add a new debug configuration to launch the extension & attach to the server simultaneously
- Add development instructions to the README

### What does this mean?
You can now debug all three components -- the extension, language server, and language service -- from their original sources, in one VS Code window.