### PR TITLE
[BREAKING CHANGE] Standardize configuration namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ To teach the extension about those, grab a copy of your schema and tell the exte
 2. Edit your workspace's `settings.json` to include this:
 ```json
 {
-  "[azure-pipelines].customSchemaFile": "./path/to/my-schema.json"
+  "azure-pipelines.customSchemaFile": "./path/to/my-schema.json"
 }
 ```
 3. Restart VS Code.

--- a/package.json
+++ b/package.json
@@ -85,7 +85,8 @@
                         "null"
                     ],
                     "default": null,
-                    "description": "Use a different schema file"
+                    "description": "Use a different schema file",
+                    "scope": "machine-overridable"
                 }
             }
         },

--- a/package.json
+++ b/package.json
@@ -80,11 +80,7 @@
                     "description": "Enable 'Configure Pipeline' feature"
                 },
                 "azure-pipelines.customSchemaFile": {
-                    "type": [
-                        "string",
-                        "null"
-                    ],
-                    "default": null,
+                    "type": "string",
                     "description": "Use a different schema file",
                     "scope": "machine-overridable"
                 }

--- a/package.json
+++ b/package.json
@@ -38,8 +38,8 @@
     ],
     "activationEvents": [
         "onLanguage:azure-pipelines",
-        "onCommand:configure-pipeline",
-        "onCommand:browse-pipeline"
+        "onCommand:azure-pipelines.configure-pipeline",
+        "onCommand:azure-pipelines.browse-pipeline"
     ],
     "main": "./out/extension",
     "contributes": {
@@ -103,12 +103,12 @@
         },
         "commands": [
             {
-                "command": "configure-pipeline",
+                "command": "azure-pipelines.configure-pipeline",
                 "title": "Configure Pipeline",
                 "category": "Azure Pipelines"
             },
             {
-                "command": "browse-pipeline",
+                "command": "azure-pipelines.browse-pipeline",
                 "title": "Browse Pipeline",
                 "category": "Azure Pipelines"
             }
@@ -116,14 +116,14 @@
         "menus": {
             "explorer/context": [
                 {
-                    "command": "configure-pipeline",
+                    "command": "azure-pipelines.configure-pipeline",
                     "group": "Azure Pipelines",
                     "when": "explorerResourceIsFolder == true"
                 }
             ],
             "commandPalette": [
                 {
-                    "command": "browse-pipeline",
+                    "command": "azure-pipelines.browse-pipeline",
                     "when": "never"
                 }
             ]

--- a/package.json
+++ b/package.json
@@ -74,12 +74,12 @@
         "configuration": {
             "title": "Azure Pipelines",
             "properties": {
-                "[azure-pipelines].configure": {
+                "azure-pipelines.configure": {
                     "type": "boolean",
                     "default": true,
                     "description": "Enable 'Configure Pipeline' feature"
                 },
-                "[azure-pipelines].customSchemaFile": {
+                "azure-pipelines.customSchemaFile": {
                     "type": [
                         "string",
                         "null"

--- a/src/configure/activate.ts
+++ b/src/configure/activate.ts
@@ -23,13 +23,13 @@ export async function activateConfigurePipeline(): Promise<AzureExtensionApiProv
     // The command has been defined in the package.json file
     // Now provide the implementation of the command with registerCommand
     // The commandId parameter must match the command field in package.json
-    registerCommand('configure-pipeline', async (actionContext: IActionContext, node: any) => {
+    registerCommand('azure-pipelines.configure-pipeline', async (actionContext: IActionContext, node: any) => {
         // The code you place here will be executed every time your command is executed
         telemetryHelper.initialize(actionContext, 'configure-pipeline');
         await configurePipeline(node);
     });
 
-    registerCommand('browse-pipeline', async (actionContext: IActionContext, node: AzureTreeItem) => {
+    registerCommand('azure-pipelines.browse-pipeline', async (actionContext: IActionContext, node: AzureTreeItem) => {
         // The code you place here will be executed every time your command is executed
         telemetryHelper.initialize(actionContext, 'browse-pipeline');
         await browsePipeline(node);

--- a/src/configure/browse.ts
+++ b/src/configure/browse.ts
@@ -33,7 +33,7 @@ export async function browsePipeline(node: AzureTreeItem): Promise<void> {
                         'Configure Pipeline');
 
                     if (result === 'Configure Pipeline') {
-                        vscode.commands.executeCommand('configure-pipeline', node);
+                        vscode.commands.executeCommand('azure-pipelines.configure-pipeline', node);
                         telemetryHelper.setTelemetry(TelemetryKeys.ClickedConfigurePipeline, 'true');
                     }
                 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -19,7 +19,7 @@ export async function activate(context: vscode.ExtensionContext) {
     extensionVariables.reporter = createTelemetryReporter(context);
     registerUiVariables(context);
 
-    const configurePipelineEnabled = vscode.workspace.getConfiguration('[azure-pipelines]').get<boolean>('configure', true);
+    const configurePipelineEnabled = vscode.workspace.getConfiguration('azure-pipelines').get<boolean>('configure', true);
     await callWithTelemetryAndErrorHandling('azurePipelines.activate', async (activateContext: IActionContext) => {
         activateContext.telemetry.properties.isActivationEvent = 'true';
         telemetryHelper.initialize(activateContext, 'activate');
@@ -88,7 +88,7 @@ async function activateYmlContributor(context: vscode.ExtensionContext) {
     // Let the server know of any schema changes.
     // TODO: move to schema-association-service?
     vscode.workspace.onDidChangeConfiguration(event => {
-        if (event.affectsConfiguration('[azure-pipelines].customSchemaFile')) {
+        if (event.affectsConfiguration('azure-pipelines.customSchemaFile')) {
             schemaAssociationService.locateSchemaFile();
             const newSchema = schemaAssociationService.getSchemaAssociation();
             client.sendNotification(SchemaAssociationNotification.type, newSchema);

--- a/src/schema-association-service.ts
+++ b/src/schema-association-service.ts
@@ -24,7 +24,7 @@ export class SchemaAssociationService implements ISchemaAssociationService {
 
     // TODO: Should this inlined into getSchemaAssocations?
     public locateSchemaFile() {
-        let alternateSchema = vscode.workspace.getConfiguration('[azure-pipelines]').get<string>('customSchemaFile');
+        let alternateSchema = vscode.workspace.getConfiguration('azure-pipelines').get<string>('customSchemaFile');
         if (alternateSchema && !path.isAbsolute(alternateSchema)) {
             alternateSchema = path.resolve(vscode.workspace.workspaceFolders[0].uri.fsPath, alternateSchema);
         }
@@ -38,7 +38,7 @@ export class SchemaAssociationService implements ISchemaAssociationService {
     // For our purposes, since we're only concerned with validating Azure Pipelines files,
     // we don't need to worry about other extensions.
     // TODO: We *could* make this configurable, but it'd probably make more sense to co-opt
-    // the existing yaml.schemas setting (and rename it to [azure-pipelines].schemas) that
+    // the existing yaml.schemas setting (and rename it to azure-pipelines.schemas) that
     // the server already looks for.
     // That one is schema -> patterns, rather than pattern -> schemas.
     public getSchemaAssociation(): ISchemaAssociations {


### PR DESCRIPTION
### Rationale

I believe #320 was caused by us using `[azure-pipelines]` for both the main configuration settings as well as language settings, and VS Code getting confused. While I wasn't able to reproduce #320, I did notice some wonkiness around where I placed my `[azure-pipelines].customSchemaFile` setting in relation to the language setting overrides.

In addition, #321 and #258 are due to those commands not being namespaced and clashing (presumably) with the identical ones defined in older versions of https://github.com/microsoft/vscode-deploy-azure.

### Proposed change

This PR standardizes the config and command namespace to `azure-pipelines`, which **is a breaking change**, but one for which I believe the benefits outweigh the downsides of asking people to update their settings file. In particular:
* `customSchemaFile` is a relatively new addition from May 2020
* Commands will continue to work; the only people who will be affected are those who added keybindings for them

Additionally, I've updated the `customSchemaFile` setting to:
* be excluded from settings sync, as filepaths are likely to change cross-machine
* be restricted to the "string" type for simplicitly

This results in a better UX experience:
| Before | After |
| -------- | ----- |
| ![customschemafile-before](https://user-images.githubusercontent.com/2766036/105276805-2dee7880-5b70-11eb-9710-3728ccfef9fc.png) | ![customschemafile-after](https://user-images.githubusercontent.com/2766036/105276868-478fc000-5b70-11eb-8ee4-8d57d68f77cf.png) |

Fixes #320
Fixes #321
Fixes #258