### PR TITLE
[Schema] Allow dashes in reference names

### DIFF
--- a/service-schema.json
+++ b/service-schema.json
@@ -3847,7 +3847,7 @@
     },
     "referenceName": {
       "type": "string",
-      "pattern": "^[_A-Za-z0-9]*$"
+      "pattern": "^[-_A-Za-z0-9]*$"
     },
     "boolean": {
       "anyOf": [


### PR DESCRIPTION
A lot of documentation on Azure Pipelines uses dashes to separate words in resources names. It seems to be working correctly and the pipeline runner does not complain. I've added the dash as a supported character in the schema so those samples stop being marked as invalid.

One example of dashes being used: https://docs.microsoft.com/en-us/azure/devops/pipelines/process/resources?view=azure-devops&tabs=example#resources-pipelines as `SmartHotel-resource`