### PR TITLE
Declare limited support for untrusted workspacs

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,10 @@
     "main": "./dist/extension",
     "capabilities": {
         "untrustedWorkspaces": {
-            "supported": true
+            "supported": "limited",
+            "restrictedConfigurations": [
+                "azure-pipelines.customSchemaFile"
+            ]
         }
     },
     "contributes": {

--- a/package.json
+++ b/package.json
@@ -41,6 +41,11 @@
         "onCommand:azure-pipelines.configure-pipeline"
     ],
     "main": "./dist/extension",
+    "capabilities": {
+        "untrustedWorkspaces": {
+            "supported": true
+        }
+    },
     "contributes": {
         "languages": [
             {


### PR DESCRIPTION
With #403, malicious repositories will be able to point the custom schema file to remote resources. While we won't try executing any code, it is _possible_ (though unlikely) that the JSON parser we use has a security vulnerability that the attacker is able to exploit. It would also be best to not ping untrusted URLs if we can avoid it.

Fixes #392.