### PR TITLE
Added missing "cwd" input property description for AzureStaticWebApp

### DIFF
--- a/service-schema.json
+++ b/service-schema.json
@@ -24501,6 +24501,11 @@
             "inputs": {
               "description": "Deploy Azure Static Web App inputs",
               "properties": {
+                "cwd": {
+                  "type": "string",
+                  "description": "Working directory",
+                  "ignoreCase": "key"
+                },
                 "app_location": {
                   "type": "string",
                   "description": "App Location",


### PR DESCRIPTION
I wrote a deployment pipeline for the new AzureStaticWebApp and noticed that the "cwd" property exists in the [AzureStaticWebAppV0 Task](https://github.com/microsoft/azure-pipelines-tasks/blob/master/Tasks/AzureStaticWebAppV0/index.ts) but it wasn't documented here.
