### PR TITLE
Move getAvailableFileName out of LocalGitRepoHelper

### DIFF
--- a/src/configure/configure.ts
+++ b/src/configure/configure.ts
@@ -20,6 +20,7 @@ import * as vscode from 'vscode';
 import { URI, Utils } from 'vscode-uri';
 import * as azdev from 'azure-devops-node-api';
 import * as templateHelper from './helper/templateHelper';
+import { getAvailableFileName } from './helper/commonHelper';
 import { ControlProvider } from './helper/controlProvider';
 import { GitHubProvider } from './helper/gitHubHelper';
 import { getSubscriptionSession } from './helper/azureSessionHelper';
@@ -535,7 +536,7 @@ class PipelineConfigurer {
 
     private async checkInPipelineFileToRepository(): Promise<void> {
         try {
-            const fileName = await LocalGitRepoHelper.GetAvailableFileName("azure-pipelines.yml", this.inputs.sourceRepository.rootUri.fsPath);
+            const fileName = await getAvailableFileName("azure-pipelines.yml", this.inputs.sourceRepository.rootUri);
             const filePath = Utils.joinPath(this.inputs.sourceRepository.rootUri, fileName);
             const content = await templateHelper.renderContent(this.inputs.pipelineParameters.pipelineTemplate.path, this.inputs);
             await vscode.workspace.fs.writeFile(filePath, Buffer.from(content));

--- a/src/configure/helper/LocalGitRepoHelper.ts
+++ b/src/configure/helper/LocalGitRepoHelper.ts
@@ -1,6 +1,5 @@
 import { GitRepositoryParameters, GitBranchDetails } from '../model/models';
 import { Messages } from '../../messages';
-import * as fs from 'fs/promises';
 import * as git from 'simple-git/promise';
 import { URI } from 'vscode-uri';
 
@@ -19,22 +18,6 @@ export class LocalGitRepoHelper {
         } catch (error) {
             throw new Error(Messages.notAGitRepository);
         }
-    }
-
-    public static async GetAvailableFileName(fileName: string, repoPath: string): Promise<string> {
-        const files = await fs.readdir(repoPath);
-        if (!files.includes(fileName)) {
-            return fileName;
-        }
-
-        for (let i = 1; i < 100; i++) {
-            let incrementalFileName = LocalGitRepoHelper.getIncrementalFileName(fileName, i);
-            if (!files.includes(incrementalFileName)) {
-                return incrementalFileName;
-            }
-        }
-
-        throw new Error(Messages.noAvailableFileNames);
     }
 
     public async getGitBranchDetails(): Promise<GitBranchDetails> {
@@ -90,10 +73,6 @@ export class LocalGitRepoHelper {
         }
 
         return gitLog.latest.hash;
-    }
-
-    private static getIncrementalFileName(fileName: string, count: number): string {
-        return fileName.substr(0, fileName.indexOf('.')).concat(` (${count})`, fileName.substr(fileName.indexOf('.')));
     }
 
     private initialize(repositoryUri: URI): void {


### PR DESCRIPTION
Observation: finding filenames has nothing to do with a local Git repo.