### PR TITLE
Upgraded simple-git to fix security audit issues.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
                 "azure-pipelines-language-server": "0.6.7",
                 "html-to-text": "^5.1.1",
                 "mustache": "3.0.1",
-                "simple-git": "1.110.0",
+                "simple-git": "^3.7.1",
                 "uuid": "^3.3.2",
                 "vscode-extension-telemetry": "^0.1.6",
                 "vscode-languageclient": "^7.0.0",
@@ -175,6 +175,19 @@
             "engines": {
                 "node": ">=10.0.0"
             }
+        },
+        "node_modules/@kwsites/file-exists": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/@kwsites/file-exists/-/file-exists-1.1.1.tgz",
+            "integrity": "sha512-m9/5YGR18lIwxSFDwfE3oA7bWuq9kdau6ugN4H2rJeyhFQZcG9AgSHkQtSD15a8WvTgfz9aikZMrKPHvbpqFiw==",
+            "dependencies": {
+                "debug": "^4.1.1"
+            }
+        },
+        "node_modules/@kwsites/promise-deferred": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/@kwsites/promise-deferred/-/promise-deferred-1.1.1.tgz",
+            "integrity": "sha512-GaHYm+c0O9MjZRu0ongGBRbinu8gVAMd2UZjji6jVmqKtZluZnptXGWhz1E8j8D2HJ3f/yMxKAUC0b+57wncIw=="
         },
         "node_modules/@nodelib/fs.scandir": {
             "version": "2.1.5",
@@ -3405,11 +3418,17 @@
             "dev": true
         },
         "node_modules/simple-git": {
-            "version": "1.110.0",
-            "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-1.110.0.tgz",
-            "integrity": "sha512-UYY0rQkknk0P5eb+KW+03F4TevZ9ou0H+LoGaj7iiVgpnZH4wdj/HTViy/1tNNkmIPcmtxuBqXWiYt2YwlRKOQ==",
+            "version": "3.7.1",
+            "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-3.7.1.tgz",
+            "integrity": "sha512-+Osjtsumbtew2y9to0pOYjNzSIr4NkKGBg7Po5SUtjQhaJf2QBmiTX/9E9cv9rmc7oUiSGFIB9e7ys5ibnT9+A==",
             "dependencies": {
-                "debug": "^4.0.1"
+                "@kwsites/file-exists": "^1.1.1",
+                "@kwsites/promise-deferred": "^1.1.1",
+                "debug": "^4.3.3"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/steveukx/"
             }
         },
         "node_modules/slash": {
@@ -4484,6 +4503,19 @@
             "resolved": "https://registry.npmjs.org/@discoveryjs/json-ext/-/json-ext-0.5.5.tgz",
             "integrity": "sha512-6nFkfkmSeV/rqSaS4oWHgmpnYw194f6hmWF5is6b0J1naJZoiD0NTc9AiUwPHvWsowkjuHErCZT1wa0jg+BLIA==",
             "dev": true
+        },
+        "@kwsites/file-exists": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/@kwsites/file-exists/-/file-exists-1.1.1.tgz",
+            "integrity": "sha512-m9/5YGR18lIwxSFDwfE3oA7bWuq9kdau6ugN4H2rJeyhFQZcG9AgSHkQtSD15a8WvTgfz9aikZMrKPHvbpqFiw==",
+            "requires": {
+                "debug": "^4.1.1"
+            }
+        },
+        "@kwsites/promise-deferred": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/@kwsites/promise-deferred/-/promise-deferred-1.1.1.tgz",
+            "integrity": "sha512-GaHYm+c0O9MjZRu0ongGBRbinu8gVAMd2UZjji6jVmqKtZluZnptXGWhz1E8j8D2HJ3f/yMxKAUC0b+57wncIw=="
         },
         "@nodelib/fs.scandir": {
             "version": "2.1.5",
@@ -6960,11 +6992,13 @@
             "dev": true
         },
         "simple-git": {
-            "version": "1.110.0",
-            "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-1.110.0.tgz",
-            "integrity": "sha512-UYY0rQkknk0P5eb+KW+03F4TevZ9ou0H+LoGaj7iiVgpnZH4wdj/HTViy/1tNNkmIPcmtxuBqXWiYt2YwlRKOQ==",
+            "version": "3.7.1",
+            "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-3.7.1.tgz",
+            "integrity": "sha512-+Osjtsumbtew2y9to0pOYjNzSIr4NkKGBg7Po5SUtjQhaJf2QBmiTX/9E9cv9rmc7oUiSGFIB9e7ys5ibnT9+A==",
             "requires": {
-                "debug": "^4.0.1"
+                "@kwsites/file-exists": "^1.1.1",
+                "@kwsites/promise-deferred": "^1.1.1",
+                "debug": "^4.3.3"
             }
         },
         "slash": {

--- a/package.json
+++ b/package.json
@@ -163,7 +163,7 @@
         "azure-pipelines-language-server": "0.6.7",
         "html-to-text": "^5.1.1",
         "mustache": "3.0.1",
-        "simple-git": "1.110.0",
+        "simple-git": "^3.7.1",
         "uuid": "^3.3.2",
         "vscode-extension-telemetry": "^0.1.6",
         "vscode-languageclient": "^7.0.0",

--- a/src/configure/helper/LocalGitRepoHelper.ts
+++ b/src/configure/helper/LocalGitRepoHelper.ts
@@ -1,10 +1,10 @@
 import { GitRepositoryParameters, GitBranchDetails } from '../model/models';
 import { Messages } from '../../messages';
-import * as git from 'simple-git/promise';
+import simpleGit, { SimpleGit } from 'simple-git';
 import { URI } from 'vscode-uri';
 
 export class LocalGitRepoHelper {
-    private gitReference: git.SimpleGit;
+    private gitReference: SimpleGit;
 
     private constructor() {
     }
@@ -76,6 +76,6 @@ export class LocalGitRepoHelper {
     }
 
     private initialize(repositoryUri: URI): void {
-        this.gitReference = git(repositoryUri.fsPath);
+        this.gitReference = simpleGit(repositoryUri.fsPath);
     }
 }


### PR DESCRIPTION
The package simple-git before 3.3.0 is vulnerable to Command Injection via argument injection. When calling the .fetch(remote, branch, handlerFn) function, both the remote and branch parameters are passed to the git fetch subcommand. By injecting some git options, it was possible to get arbitrary command execution. 