### PR TITLE
Expand schema auto-detection to all workspaces

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -28,7 +28,8 @@
                 "--extensionTestsPath=${workspaceFolder}/out/test/index"
             ],
             "outFiles": [
-                "${workspaceFolder}/out/test/**/*.js"
+                "${workspaceFolder}/dist/**/*.js",
+                "${workspaceFolder}/out/**/*.js"
             ],
             "preLaunchTask": "npm: compile:test",
         },

--- a/src/configure/clients/devOps/organizationsClient.ts
+++ b/src/configure/clients/devOps/organizationsClient.ts
@@ -57,7 +57,7 @@ export class OrganizationsClient {
             method: "GET",
             queryParameters: {
                 "memberId": connectionData.authenticatedUser.id,
-                "api-version": "5.0",
+                "api-version": "7.0",
             },
         });
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -71,7 +71,7 @@ async function activateYmlContributor(context: vscode.ExtensionContext) {
     }
 
     // And subscribe to future open events, as well.
-    context.subscriptions.push(vscode.workspace.onDidOpenTextDocument(async textDocument => {
+    context.subscriptions.push(vscode.workspace.onDidOpenTextDocument(async () => {
         await loadSchema(context, client);
     }));
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -71,8 +71,16 @@ async function activateYmlContributor(context: vscode.ExtensionContext) {
     }
 
     // And subscribe to future open events, as well.
-    context.subscriptions.push(vscode.workspace.onDidOpenTextDocument(async () => {
-        await loadSchema(context, client);
+    context.subscriptions.push(vscode.workspace.onDidOpenTextDocument(async textDocument => {
+        // NOTE: We need to explicitly compute the workspace folder here rather than
+        // relying on the logic in loadSchema, because somehow preview editors
+        // don't count as "active".
+        if (textDocument?.languageId !== 'azure-pipelines') {
+            return;
+        }
+
+        const workspaceFolder = vscode.workspace.getWorkspaceFolder(textDocument.uri);
+        await loadSchema(context, client, workspaceFolder);
     }));
 
     // Re-request the schema on Azure login since auto-detection is dependent on login.

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -8,7 +8,7 @@ import * as vscode from 'vscode';
 import * as languageclient from 'vscode-languageclient/node';
 
 import * as logger from './logger';
-import { getSchemaAssociation, locateSchemaFile, SchemaAssociationNotification } from './schema-association-service';
+import { getSchemaAssociation, locateSchemaFile, onDidSelectOrganization, SchemaAssociationNotification } from './schema-association-service';
 import { schemaContributor, CUSTOM_SCHEMA_REQUEST, CUSTOM_CONTENT_REQUEST } from './schema-contributor';
 import { telemetryHelper } from './helpers/telemetryHelper';
 import { getAzureAccountExtensionApi } from './extensionApis';
@@ -74,6 +74,12 @@ async function activateYmlContributor(context: vscode.ExtensionContext) {
         if (status === 'LoggedIn') {
             await loadSchema(context, client);
         }
+    }));
+
+    // We now have an organization for non-Azure Repos workspaces,
+    // so we can try auto-detecting the schema again.
+    context.subscriptions.push(onDidSelectOrganization(async () => {
+        await loadSchema(context, client);
     }));
 }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -66,7 +66,7 @@ async function activateYmlContributor(context: vscode.ExtensionContext) {
     }));
 
     // Load the schema if we were activated because an Azure Pipelines file.
-    if (vscode.window.activeTextEditor.document.languageId === 'azure-pipelines') {
+    if (vscode.window.activeTextEditor?.document.languageId === 'azure-pipelines') {
         await loadSchema(context, client);
     }
 
@@ -96,8 +96,8 @@ async function loadSchema(
     client: languageclient.LanguageClient,
     workspaceFolder?: vscode.WorkspaceFolder): Promise<void> {
     if (workspaceFolder === undefined) {
-        const textDocument = vscode.window.activeTextEditor.document;
-        if (textDocument.languageId !== 'azure-pipelines') {
+        const textDocument = vscode.window.activeTextEditor?.document;
+        if (textDocument?.languageId !== 'azure-pipelines') {
             return;
         }
 

--- a/src/messages.ts
+++ b/src/messages.ts
@@ -41,8 +41,9 @@ export class Messages {
     public static resourceTypeIsNotSupported: string = '"%s" resources are not yet supported for configuring pipelines.';
     public static selectFolderLabel: string = 'Select source folder for configuring pipeline';
     public static selectOrganization: string = 'Select an Azure DevOps organization';
-    public static selectOrganizationForEnhancedIntelliSense: string = 'Select Azure DevOps organization associated with this folder for enhanced Azure Pipelines IntelliSense.';
+    public static selectOrganizationForEnhancedIntelliSense: string = 'Select Azure DevOps organization associated with the %s repository for enhanced Azure Pipelines IntelliSense.';
     public static selectOrganizationLabel: string = 'Select organization';
+    public static selectOrganizationPlaceholder: string = 'Select Azure DevOps organization associated with the %s repository';
     public static selectPipelineTemplate: string = 'Select an Azure Pipelines template...';
     public static selectProject: string = 'Select an Azure DevOps project';
     public static selectRemoteForBranch: string = 'Select the remote repository where you want to track your current branch';

--- a/src/messages.ts
+++ b/src/messages.ts
@@ -41,6 +41,8 @@ export class Messages {
     public static resourceTypeIsNotSupported: string = '"%s" resources are not yet supported for configuring pipelines.';
     public static selectFolderLabel: string = 'Select source folder for configuring pipeline';
     public static selectOrganization: string = 'Select an Azure DevOps organization';
+    public static selectOrganizationForEnhancedIntelliSense: string = 'Select Azure DevOps organization associated with this folder for enhanced Azure Pipelines IntelliSense.';
+    public static selectOrganizationLabel: string = 'Select organization';
     public static selectPipelineTemplate: string = 'Select an Azure Pipelines template...';
     public static selectProject: string = 'Select an Azure DevOps project';
     public static selectRemoteForBranch: string = 'Select the remote repository where you want to track your current branch';
@@ -49,6 +51,7 @@ export class Messages {
     public static selectFunctionApp: string = 'Select Function App';
     public static selectWorkspaceFolder: string = 'Select a folder from your workspace to deploy';
     public static signInLabel: string = 'Sign In';
+    public static unableToAccessOrganization: string = 'Unable to access the "%s" organization. Make sure you\'re signed into the right Azure account.';
     public static unableToCreateServiceConnection: string = `Unable to create %s service connection.\nOperation Status: %s\nMessage: %s\nService connection is not in ready state.`;
     public static timedOutCreatingServiceConnection: string =`Timed out creating %s service connection.\nService connection is not in ready state.`;
     public static retryFailedMessage: string =`Failed after retrying: %s times. Internal Error: %s`;

--- a/src/schema-association-service.ts
+++ b/src/schema-association-service.ts
@@ -99,7 +99,11 @@ async function autoDetectSchema(
     // Get the remote URL if we're in a Git repo.
     let remoteUrl: string | undefined;
     const gitExtension = await getGitExtensionApi();
-    const repo = gitExtension.getRepository(workspaceFolder.uri);
+
+    // Use openRepository because it's possible the Git extension hasn't
+    // finished opening all the repositories yet, and thus getRepository
+    // may return null if an Azure Pipelines file is open on startup.
+    const repo = await gitExtension.openRepository(workspaceFolder.uri);
     if (repo !== null) {
         await repo.status();
         if (repo.state.HEAD?.upstream !== undefined) {

--- a/src/schema-association-service.ts
+++ b/src/schema-association-service.ts
@@ -14,6 +14,7 @@ import { OrganizationsClient } from './configure/clients/devOps/organizationsCli
 import { AzureDevOpsHelper } from './configure/helper/devOps/azureDevOpsHelper';
 import { showQuickPick } from './configure/helper/controlProvider';
 import { QuickPickItemWithData } from './configure/model/models';
+import * as logger from './logger';
 import { Messages } from './messages';
 import { AzureSession } from './typings/azure-account.api';
 
@@ -38,7 +39,8 @@ export async function locateSchemaFile(
             }
         } catch (error) {
             // Well, we tried our best. Fall back to the predetermined schema paths.
-            // TODO: Start exposing errors once we're more confident in the schema detection.
+            // TODO: Re-throw error once we're more confident in the schema detection.
+            logger.log(`Error auto-detecting schema: ${error}`, 'SchemaAutoDetectError');
         }
     }
 

--- a/src/schema-association-service.ts
+++ b/src/schema-association-service.ts
@@ -60,6 +60,9 @@ export async function locateSchemaFile(
         schemaUri = vscode.Uri.file(path.join(context.extensionPath, 'service-schema.json'));
     }
 
+    // TODO: We should update getSchemaAssociations so we don't need to constantly
+    // notify the server of a "new" schema when in reality we're simply updating
+    // associations -- which is exactly what getSchemaAssociations is there for!
     return schemaUri.toString();
 }
 

--- a/src/schema-association-service.ts
+++ b/src/schema-association-service.ts
@@ -15,6 +15,9 @@ import { QuickPickItemWithData } from './configure/model/models';
 import { Messages } from './messages';
 import { AzureSession } from './typings/azure-account.api';
 
+// TODO: In order to support Pipelines files from multiple workspaces,
+// we need to call this on _every_ Azure Pipelines file open event,
+// not just at startup/config change.
 export async function locateSchemaFile(context: vscode.ExtensionContext): Promise<string> {
     let schemaUri: vscode.Uri | undefined;
     try {
@@ -91,9 +94,6 @@ async function autoDetectSchema(context: vscode.ExtensionContext): Promise<vscod
             return undefined;
         }
 
-        // Create the global storage folder to guarantee that it exists.
-        await vscode.workspace.fs.createDirectory(context.globalStorageUri);
-
         // Prompt for the right Azure session to use.
         let session: AzureSession;
         if (azureAccountApi.sessions.length > 1) {
@@ -110,6 +110,9 @@ async function autoDetectSchema(context: vscode.ExtensionContext): Promise<vscod
         } else {
             session = azureAccountApi.sessions[0];
         }
+
+        // Create the global storage folder to guarantee that it exists.
+        await vscode.workspace.fs.createDirectory(context.globalStorageUri);
 
         // Grab and save the schema.
         // NOTE: Despite saving the schema to disk, we don't treat it as a cache

--- a/src/schema-association-service.ts
+++ b/src/schema-association-service.ts
@@ -35,7 +35,7 @@ export async function locateSchemaFile(
         try {
             schemaUri = await autoDetectSchema(context, workspaceFolder);
             if (schemaUri) {
-                return schemaUri.toString();
+                return schemaUri.path;
             }
         } catch (error) {
             // Well, we tried our best. Fall back to the predetermined schema paths.
@@ -63,7 +63,7 @@ export async function locateSchemaFile(
     // TODO: We should update getSchemaAssociations so we don't need to constantly
     // notify the server of a "new" schema when in reality we're simply updating
     // associations -- which is exactly what getSchemaAssociations is there for!
-    return schemaUri.toString();
+    return schemaUri.path;
 }
 
 // Looking at how the vscode-yaml extension does it, it looks like this is meant as a

--- a/src/schema-association-service.ts
+++ b/src/schema-association-service.ts
@@ -20,9 +20,10 @@ import { AzureSession } from './typings/azure-account.api';
 const selectOrganizationEvent: vscode.EventEmitter<void> = new vscode.EventEmitter<void>();
 export const onDidSelectOrganization = selectOrganizationEvent.event;
 
-// TODO: In order to support Pipelines files from multiple workspaces,
+// TODO: In order to support Pipelines files from multiple folders in a workspace,
 // we need to call this on _every_ Azure Pipelines file open event,
 // not just at startup/config change.
+// Will need to listen to vscode.workspace.onDidOpenTextDocument in extension.ts.
 export async function locateSchemaFile(context: vscode.ExtensionContext): Promise<string> {
     let schemaUri: vscode.Uri | undefined;
     try {
@@ -32,7 +33,7 @@ export async function locateSchemaFile(context: vscode.ExtensionContext): Promis
         }
     } catch (error) {
         // Well, we tried our best. Fall back to the predetermined schema paths.
-        // TODO: Stop try/catching this once we're more confident in the schema detection.
+        // TODO: Start exposing errors once we're more confident in the schema detection.
     }
 
     let alternateSchema = vscode.workspace.getConfiguration('azure-pipelines').get<string>('customSchemaFile');

--- a/src/test/runTest.ts
+++ b/src/test/runTest.ts
@@ -25,7 +25,11 @@ async function main() {
     const vscodeExecutablePath = await downloadAndUnzipVSCode();
     const cliPath = resolveCliPathFromVSCodeExecutablePath(vscodeExecutablePath);
 
-    cp.spawnSync(cliPath, ['--install-extension', 'ms-vscode.azure-account'], {
+    // 0.11.0 has a bug where it blocks extension loading on first launch:
+    // https://github.com/microsoft/vscode-azure-account/pull/603.
+    // Since we always launch for the first time in CI, that turns out
+    // to be problematic.
+    cp.spawnSync(cliPath, ['--install-extension', 'ms-vscode.azure-account@0.10.1'], {
       encoding: 'utf-8',
       stdio: 'inherit'
     });


### PR DESCRIPTION
#449 added basic support for schema auto-detection, limited to Git repositories with an Azure Repo remote and a single Azure account.

This PR expands that support to work on _all_ workspaces by introducing a prompt to select the right Azure session.
The flow looks something like this:
1. If not logged in to Azure, display a login prompt and return early.
2. Check if the current workspace has an Azure Repo remote. If it does, go to step 3. If not, go to step 4.
3. [Azure Repos] For every Azure session, see if it has access to the Azure DevOps organization and record the matching session. Go to step 6.
4. [Other workspaces] If the workspace is already associated with an ADO organization, go to step 6. Otherwise, display a prompt with all the organizations associated with the Azure account and ask which one is associated with the workspace.
5. [Other workspaces] Update the workspace state with the new association.
6. [Both] If session is undefined, return early.
7. If the organization is already in the session-level cache, return the cached schema file.
8. Authenticate to the ADO APIs using the given Azure session and download the schema.
9. Add the organization to the session-level cache so that reopening the file later on doesn't trigger a re-download.

Closes #58.
Fixes #482.

Potential future followups:
* Fix the Azure session race condition
* Expand auto-detection to work for Azure Pipelines files opened outside of a workspace
* Optimize schema selection to send a schema association update, rather than overwriting the existing wildcard association
* Use the new language status bar API to indicate what schema is being used