### PR TITLE
Indicate that 'environment' is require for deployment jobs

### DIFF
--- a/service-schema.json
+++ b/service-schema.json
@@ -2310,6 +2310,9 @@
           "additionalProperties": false,
           "firstProperty": [
             "deployment"
+          ],
+          "required": [
+            "environment"
           ]
         },
         {


### PR DESCRIPTION
- Without this a build will fail with: "Environment is required."