### PR TITLE
Recognize more common filename patterns as Azure Pipelines files

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,16 +56,13 @@
                 "id": "azure-pipelines",
                 "configuration": "./language-configuration.json",
                 "filenamePatterns": [
-                    "azure-pipelines.yml",
-                    "azure-pipelines.yaml",
-                    ".azure-pipelines.yml",
-                    ".azure-pipelines.yaml",
-                    "azure-pipelines/**/*.yml",
-                    "azure-pipelines/**/*.yaml",
-                    ".azure-pipelines/**/*.yml",
-                    ".azure-pipelines/**/*.yaml",
-                    ".vsts-ci.yml",
-                    "vsts-ci.yml"
+                    "azure-pipelines.{yml,yaml}",
+                    ".azure-pipelines.{yml,yaml}",
+                    "**/azure-pipelines/**/*.{yml,yaml}",
+                    "**/.azure-pipelines/**/*.{yml,yaml}",
+                    "**/.pipelines/**/*.{yml,yaml}",
+                    "vsts-ci.{yml,yaml}",
+                    ".vsts-ci.{yml,yaml}"
                 ],
                 "aliases": [
                     "Azure Pipelines"

--- a/src/test/suite/configuration.test.ts
+++ b/src/test/suite/configuration.test.ts
@@ -1,0 +1,47 @@
+import * as vscode from 'vscode';
+import * as assert from 'assert';
+
+function getWorkspaceFolder() {
+    return vscode.workspace.workspaceFolders?.[0] ?? assert.fail('No workspace folder');
+}
+
+suite('Language configuration', () => {
+    suite('Filename patterns', () => {
+        const trackedUris: vscode.Uri[] = [];
+
+        async function assertFileIsAzurePipelines(...pathComponents: string[]): Promise<void> {
+            const uri = vscode.Uri.joinPath(getWorkspaceFolder().uri, ...pathComponents);
+            await vscode.workspace.fs.writeFile(uri, new Uint8Array());
+            trackedUris.push(uri);
+
+            const doc = await vscode.workspace.openTextDocument(uri);
+            assert.strictEqual(doc.languageId, 'azure-pipelines');
+        }
+
+        suiteTeardown(async () => {
+            await Promise.all(trackedUris.map(uri => vscode.workspace.fs.delete(uri)));
+        });
+
+        for (const extension of ['yml', 'yaml']) {
+            test(`Detects azure-pipelines.${extension}`, async () => {
+                await assertFileIsAzurePipelines(`azure-pipelines.${extension}`);
+            });
+
+            test(`Detects .azure-pipelines.${extension}`, async () => {
+                await assertFileIsAzurePipelines(`.azure-pipelines.${extension}`);
+            });
+
+            test(`Detects azure-pipelines/anything.${extension}`, async () => {
+                await assertFileIsAzurePipelines('azure-pipelines', `anything.${extension}`);
+            });
+
+            test(`Detects .azure-pipelines/anything.${extension}`, async () => {
+                await assertFileIsAzurePipelines('.azure-pipelines', `anything.${extension}`);
+            });
+
+            test(`Detects .pipelines/anything.${extension}`, async () => {
+                await assertFileIsAzurePipelines('.pipelines', `anything.${extension}`);
+            });
+        }
+    });
+});


### PR DESCRIPTION
Match any YAML file under a `.pipelines` folder ([4k hits](https://github.com/search?q=language%3Ayaml+path%3A.pipelines&type=code)) and fix the folder patterns for `.azure-pipelines` never matching ([13k hits](https://github.com/search?q=language%3Ayaml+path%3A.azure-pipelines&type=code)).

Add tests to make sure this doesn't regress :).