### PR TITLE
Account for case-sensitivity when looking up organizations

### DIFF
--- a/src/schema-association-service.ts
+++ b/src/schema-association-service.ts
@@ -247,7 +247,7 @@ async function autoDetectSchema(
 
     const organizationsClient = new OrganizationsClient(azureDevOpsSession.accessToken);
     const organizations = await organizationsClient.listOrganizations();
-    if (!organizations.map(({ accountName }) => accountName).includes(organizationName)) {
+    if (!organizations.map(({ accountName }) => accountName.toLowerCase()).includes(organizationName.toLowerCase())) {
         logger.log(`Account does not have access to ${organizationName}`, 'SchemaDetection');
 
         void vscode.window.showErrorMessage(


### PR DESCRIPTION
If the casing of the organization in the Git remote is different than the one returned to us by ADO's Accounts API, that shouldn't matter! Organization names are case-insensitive.

Fixes #615 