### PR TITLE
Support shorthand Azure Repos URLs

### DIFF
--- a/src/helpers/azureDevOpsHelper.ts
+++ b/src/helpers/azureDevOpsHelper.ts
@@ -19,14 +19,43 @@ export function isAzureReposUrl(remoteUrl: string): boolean {
         remoteUrl.includes(SSHVsoReposUrl);
 }
 
+/**
+ * Gets the organization name, project name, and repository name from a given Azure Repos URL.
+ *
+ * Note that Azure Repos support _many_ formats.
+ * Here's all the ones we know of:
+ * * New-style HTTPS: https://dev.azure.com/<organization>/<project>/_git/<repository>
+ * * Old-style HTTPS: https://<organization>.visualstudio.com/<project>/_git/<repository>
+ * * New-style shorthand HTTPS: https://dev.azure.com/<organization>/_git/<repository>
+ * * Old-style shorthand HTTPS: https://<organization>.visualstudio.com/_git/<repository>
+ * * Old-style default collection HTTPS: https://<organization>.visualstudio.com/DefaultCollection/<project>/_git/<repository>
+ * * Old-style default collection shorthand HTTPS: https://<organization>.visualstudio.com/DefaultCollection/_git/<repository>
+ * * New-style SSH: git@ssh.dev.azure.com:v3/<organization>/<project>/<repository>
+ * * Old-style SSH: <organization>@vs-ssh.visualstudio.com:v3/<organization>/<project>/<repository>
+ *
+ * @param remoteUrl The Azure Repos URL to parse.
+ * @returns Details about the URL.
+ */
 export function getRepositoryDetailsFromRemoteUrl(remoteUrl: string): { organizationName: string, projectName: string, repositoryName: string } {
     if (remoteUrl.includes(AzureReposUrl)) {
         const part = remoteUrl.substring(remoteUrl.indexOf(AzureReposUrl) + AzureReposUrl.length);
         const parts = part.split('/');
+
+        if (parts.length === 3) {
+            // Shorthand URL: project & repository are the same, project is not specified.
+            // https://dev.azure.com/<organization>/_git/<repository>
+            return {
+                organizationName: parts[0].trim(),
+                projectName: parts[2].trim(),
+                repositoryName: parts[2].trim()
+            };
+        }
+
         if (parts.length !== 4) {
             throw new Error(Messages.failedToDetermineAzureRepoDetails);
         }
 
+        // https://dev.azure.com/<organization>/<project>/_git/<repository>
         return {
             organizationName: parts[0].trim(),
             projectName: parts[1].trim(),
@@ -37,15 +66,27 @@ export function getRepositoryDetailsFromRemoteUrl(remoteUrl: string): { organiza
         const organizationName = remoteUrl.substring(remoteUrl.indexOf('https://') + 'https://'.length, remoteUrl.indexOf('.visualstudio.com'));
         const parts = part.split('/');
 
-        if (parts.length === 4 && parts[0].toLowerCase() === 'defaultcollection') {
-            // Handle scenario where part is 'DefaultCollection/<project>/_git/<repository>'
+        if (parts[0].toLowerCase() === 'defaultcollection') {
+            // Remove DefaultCollection from the URL.
+            // Luckily, projects can't be named DefaultCollection, so this is always safe.
             parts.shift();
+        }
+
+        if (parts.length === 2) {
+            // Shorthand URL: project & repository are the same, project is not specified.
+            // https://<organization>.visualstudio.com/_git/<repository>
+            return {
+                organizationName: organizationName,
+                projectName: parts[1].trim(),
+                repositoryName: parts[1].trim()
+            };
         }
 
         if (parts.length !== 3) {
             throw new Error(Messages.failedToDetermineAzureRepoDetails);
         }
 
+        // https://<organization>.visualstudio.com/<project>/_git/<repository>
         return {
             organizationName: organizationName,
             projectName: parts[0].trim(),

--- a/src/test/suite/azureDevOpsHelper.test.ts
+++ b/src/test/suite/azureDevOpsHelper.test.ts
@@ -1,0 +1,100 @@
+import * as assert from 'assert';
+import { getRepositoryDetailsFromRemoteUrl, isAzureReposUrl } from '../../helpers/azureDevOpsHelper';
+
+suite('Azure DevOps Helpers', () => {
+    suite('isAzureReposUrl', () => {
+        test('Returns true for dev.azure.com URLs', () => {
+            assert.ok(isAzureReposUrl('https://dev.azure.com/organization/project/_git/repo'));
+        });
+
+        test('Returns true for visualstudio.com URLs', () => {
+            assert.ok(isAzureReposUrl('https://organization.visualstudio.com/project/_git/repo'));
+        });
+
+        test('Returns true for SSH dev.azure.com URLs', () => {
+            assert.ok(isAzureReposUrl('git@ssh.dev.azure.com:v3/organization/project/repo'));
+        });
+
+        test('Returns true for SSH visualstudio.com URLs', () => {
+            assert.ok(isAzureReposUrl('organization@vs-ssh.visualstudio.com:v3/organization/project/repo'));
+        });
+
+        test('Returns false for other URLs', () => {
+            assert.ok(!isAzureReposUrl('https://azure.com/organization/project/_git/repo'));
+            assert.ok(!isAzureReposUrl('https://visualstudio.com/project/_git/repo'));
+            assert.ok(!isAzureReposUrl('https://github.com/owner/repo.git'));
+        });
+    });
+
+    suite('getRepositoryDetailsFromRemoteUrl', () => {
+        test('Returns correct details for dev.azure.com URLs', () => {
+            const details = getRepositoryDetailsFromRemoteUrl('https://dev.azure.com/organization/project/_git/repo');
+            assert.strictEqual(details.organizationName, 'organization');
+            assert.strictEqual(details.projectName, 'project');
+            assert.strictEqual(details.repositoryName, 'repo');
+        });
+
+        test('Returns correct details for shorthand dev.azure.com URLs', () => {
+            const details = getRepositoryDetailsFromRemoteUrl('https://dev.azure.com/organization/_git/repo');
+            assert.strictEqual(details.organizationName, 'organization');
+            assert.strictEqual(details.projectName, 'repo');
+            assert.strictEqual(details.repositoryName, 'repo');
+        });
+
+        test('Returns correct details for visualstudio.com URLs', () => {
+            const details = getRepositoryDetailsFromRemoteUrl('https://organization.visualstudio.com/project/_git/repo');
+            assert.strictEqual(details.organizationName, 'organization');
+            assert.strictEqual(details.projectName, 'project');
+            assert.strictEqual(details.repositoryName, 'repo');
+        });
+
+        test('Returns correct details for shorthand visualstudio.com URLs', () => {
+            const details = getRepositoryDetailsFromRemoteUrl('https://organization.visualstudio.com/_git/repo');
+            assert.strictEqual(details.organizationName, 'organization');
+            assert.strictEqual(details.projectName, 'repo');
+            assert.strictEqual(details.repositoryName, 'repo');
+        });
+
+        test('Returns correct details for DefaultCollection visualstudio.com URLs', () => {
+            const details = getRepositoryDetailsFromRemoteUrl('https://organization.visualstudio.com/DeFaUlTcOlLeCtIoN/project/_git/repo');
+            assert.strictEqual(details.organizationName, 'organization');
+            assert.strictEqual(details.projectName, 'project');
+            assert.strictEqual(details.repositoryName, 'repo');
+        });
+
+        test('Returns correct details for shorthand DefaultCollection visualstudio.com URLs', () => {
+            const details = getRepositoryDetailsFromRemoteUrl('https://organization.visualstudio.com/DeFaUlTcOlLeCtIoN/_git/repo');
+            assert.strictEqual(details.organizationName, 'organization');
+            assert.strictEqual(details.projectName, 'repo');
+            assert.strictEqual(details.repositoryName, 'repo');
+        });
+
+        test('Returns correct details for SSH dev.azure.com URLs', () => {
+            const details = getRepositoryDetailsFromRemoteUrl('git@ssh.dev.azure.com:v3/organization/project/repo');
+            assert.strictEqual(details.organizationName, 'organization');
+            assert.strictEqual(details.projectName, 'project');
+            assert.strictEqual(details.repositoryName, 'repo');
+        });
+
+        test('Returns correct details for SSH visualstudio.com URLs', () => {
+            const details = getRepositoryDetailsFromRemoteUrl('organization@vs-ssh.visualstudio.com:v3/organization/project/repo');
+            assert.strictEqual(details.organizationName, 'organization');
+            assert.strictEqual(details.projectName, 'project');
+            assert.strictEqual(details.repositoryName, 'repo');
+        });
+
+        test('Throws error for invalid URLs', () => {
+            assert.throws(() => {
+                getRepositoryDetailsFromRemoteUrl('https://invalid.url/organization/project/_git/repo');
+            }, "The repo isn't hosted with Azure Repos");
+
+            assert.throws(() => {
+                getRepositoryDetailsFromRemoteUrl('https:/dev.azure.com/DefaultCollection/organization/project/_git/repo');
+            }, /Failed to determine Azure Repo details/);
+
+            assert.throws(() => {
+                getRepositoryDetailsFromRemoteUrl('https://organization.visualstudio.com/invalid');
+            }, /Failed to determine Azure Repo details/);
+        });
+    });
+});


### PR DESCRIPTION
When a repository has the same name as its containing project, ADO allows you to elide the project, leading to a URL of `https://dev.azure.com/organization/_git/repository`.

Support that scenario and also add tests to make sure everything works.

Fixes #621