### PR TITLE
Remove signing and disable CI

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -13,7 +13,7 @@
 # This Yaml Document has been converted by ESAI Yaml Pipeline Conversion Tool.
 # This pipeline will be extended to the OneESPT template
 trigger:
-  - main
+  - none
   
   # no `pr` keyword because we want all PRs to run this
 resources:
@@ -70,3 +70,5 @@ extends:
           displayName: Set version number of package and build
 
         - template: /.azure-pipelines/common-steps.yml@self
+          parameters:
+            signExtension: false

--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -69,5 +69,3 @@ extends:
           displayName: Set version number of package and build
 
         - template: /.azure-pipelines/common-steps.yml@self
-          parameters:
-            signExtension: false

--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -12,8 +12,7 @@
 
 # This Yaml Document has been converted by ESAI Yaml Pipeline Conversion Tool.
 # This pipeline will be extended to the OneESPT template
-trigger:
-  - none
+trigger: none
   
   # no `pr` keyword because we want all PRs to run this
 resources:

--- a/.azure-pipelines/common-steps.yml
+++ b/.azure-pipelines/common-steps.yml
@@ -1,6 +1,11 @@
 # Common steps template
 #
 # Things which happen regardless of CI, PR, or release builds
+parameters:
+- name: signExtension
+  type: boolean
+  default: true
+
 steps:
 - task: NodeTool@0
   displayName: Install Node 16 LTS or greater
@@ -45,36 +50,37 @@ steps:
     cp extension.manifest extension.signature.p7s
   displayName: Prepare Manifest Signature
 
-- task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@5
-  inputs:
-    ConnectedServiceName: $(ConnectedServiceName)
-    UseMSIAuthentication: true
-    AppRegistrationClientId: $(AppRegistrationClientId)
-    AppRegistrationTenantId: $(AppRegistrationTenantId)
-    EsrpClientId: $(EsrpClientId)
-    AuthAKVName: $(AuthAKVName)
-    AuthCertName: $(AuthCertName)
-    AuthSignCertName: $(AuthSignCertName)
-    ServiceEndpointUrl: $(ESRPServiceEndpointUrl)
-    FolderPath: '$(Build.SourcesDirectory)'
-    Pattern: 'extension.signature.p7s'
-    signConfigType: inlineSignParams
-    inlineOperation: |
-      [
-        {
-          "keyCode": "CP-401405",
-          "operationSetCode": "VSCodePublisherSign",
-          "parameters" : [],
-          "toolName": "sign",
-          "toolVersion": "1.0"
-        }
-      ]
-    SessionTimeout: 90
-    MaxConcurrency: 25
-    MaxRetryAttempts: 5
-    PendingAnalysisWaitTimeoutMinutes: 5
-  displayName: Sign Extension
-  condition: and(succeeded(), ne(variables['build.reason'], 'PullRequest'))
+- ${{ if parameters.signExtension }}:
+  - task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@5
+    inputs:
+      ConnectedServiceName: $(ConnectedServiceName)
+      UseMSIAuthentication: true
+      AppRegistrationClientId: $(AppRegistrationClientId)
+      AppRegistrationTenantId: $(AppRegistrationTenantId)
+      EsrpClientId: $(EsrpClientId)
+      AuthAKVName: $(AuthAKVName)
+      AuthCertName: $(AuthCertName)
+      AuthSignCertName: $(AuthSignCertName)
+      ServiceEndpointUrl: $(ESRPServiceEndpointUrl)
+      FolderPath: '$(Build.SourcesDirectory)'
+      Pattern: 'extension.signature.p7s'
+      signConfigType: inlineSignParams
+      inlineOperation: |
+        [
+          {
+            "keyCode": "CP-401405",
+            "operationSetCode": "VSCodePublisherSign",
+            "parameters" : [],
+            "toolName": "sign",
+            "toolVersion": "1.0"
+          }
+        ]
+      SessionTimeout: 90
+      MaxConcurrency: 25
+      MaxRetryAttempts: 5
+      PendingAnalysisWaitTimeoutMinutes: 5
+    displayName: Sign Extension
+    condition: and(succeeded(), ne(variables['build.reason'], 'PullRequest'))
   
 - script: |
     npm run vscode:prepublish

--- a/.azure-pipelines/common-steps.yml
+++ b/.azure-pipelines/common-steps.yml
@@ -4,7 +4,7 @@
 parameters:
 - name: signExtension
   type: boolean
-  default: true
+  default: false
 
 steps:
 - task: NodeTool@0

--- a/.azure-pipelines/release-pipeline.yml
+++ b/.azure-pipelines/release-pipeline.yml
@@ -56,6 +56,8 @@ extends:
 
         # do all the normal build stuff
         - template: /.azure-pipelines/common-steps.yml@self
+          parameters:
+            signExtension: true
 
         # if the mini changelog is empty, complain
         - bash: |


### PR DESCRIPTION
This PR disables the automatic CI trigger for the VS Code extension **CI** pipeline (`.azure-pipelines/azure-pipelines.yml`) and makes ESRP publisher signing of the VSIX opt-in via a template parameter, so that CI builds no longer sign while the release pipeline continues to sign and publish. Signing is parameterized (not deleted) in the shared `common-steps.yml` template.

**Trigger change**
* `.azure-pipelines/azure-pipelines.yml`: changed the trigger from `main` to `trigger: none`, so this pipeline no longer runs automatically on branch pushes. PR validation is unaffected (there is intentionally no `pr:` key, so all PRs still build).

**Signing parameterization (opt-in)**
* `.azure-pipelines/common-steps.yml`: added a `signExtension` parameter (`type: boolean`, `default: false`) and wrapped the `Sign Extension` (`EsrpCodeSigning@5`) step in `${{ if parameters.signExtension }}`, so signing is excluded at compile time unless a caller opts in.
* `.azure-pipelines/azure-pipelines.yml` (CI): does not pass `signExtension`, so it uses the default `false` — signing is off for CI.
* `.azure-pipelines/release-pipeline.yml`: explicitly passes `signExtension: true`, so the release pipeline continues to sign the VSIX.

### **Context**
Disable the automatic CI trigger and ESRP publisher signing for the VS Code extension **CI** pipeline. Signing was made a template parameter (rather than removed) because `common-steps.yml` is shared with `release-pipeline.yml`, which **publishes the signed VSIX to the Marketplace** (`vsce publish ... --signaturePath extension.signature.p7s`). The default (`signExtension: false`) turns signing off for CI, and the release pipeline opts back in with `signExtension: true`.

_No linked ADO Work Item / GitHub issue — add here if applicable._

---

### **Description**
- `azure-pipelines.yml` (CI): `trigger:` (`main`) → `trigger: none`; does not pass `signExtension` (uses default `false`).
- `common-steps.yml` (shared): added `signExtension` (`type: boolean`, `default: false`) and gated the `Sign Extension` `EsrpCodeSigning@5` step behind `${{ if parameters.signExtension }}`.
- `release-pipeline.yml`: passes `signExtension: true` to `common-steps.yml`.

Net effect: the CI pipeline no longer auto-triggers on push and no longer signs the VSIX (default `signExtension: false`). The release pipeline explicitly opts in (`signExtension: true`) and continues to sign and publish.

---

### **Risk Assessment** (Low / Medium / High)
**Low.** Changes are limited to three CI YAML files and scoped to trigger + signing behavior.
- Signing is now opt-in; `release-pipeline.yml` explicitly passes `signExtension: true`, so it still produces a signed, publishable VSIX. CI produces an **unsigned** VSIX (acceptable; CI VSIX is for buddy-testing, not Marketplace publishing).
- The `Prepare Manifest Signature` step still creates `extension.signature.p7s`, so the `CopyFiles`/artifact-publish step does not fail — the CI artifact simply carries an unsigned signature file.
- `signExtension` is a typed `boolean`, so `${{ if parameters.signExtension }}` evaluates correctly (a typed `false` is falsy and removes the step at compile time).

---

### **Change Behind Feature Flag** (Yes / No)
**No.** These are pipeline configuration changes (trigger + template parameter), not runtime product code. Signing is controlled by the new `signExtension` template parameter.

---

### **Tech Design / Approach**
- Signing was **parameterized, not removed**, to avoid affecting `release-pipeline.yml`, which shares `common-steps.yml` and publishes the signed VSIX.
- The parameter is a typed `boolean`, so the gate uses a simple `${{ if parameters.signExtension }}`.
- Default `signExtension: false` makes signing **opt-in**; only the release pipeline passes `signExtension: true`.
- The signing step already only ran on non-PR builds (`ne(build.reason, 'PullRequest')`), so PRs never signed; this change makes it opt-in for non-PR runs as well.
- Alternative considered: unconditionally deleting the `Sign Extension` step from the shared template — rejected because it would break Marketplace publishing from the release pipeline.

---

### **Documentation Changes Required** (Yes/No)
**No.** No user-facing docs, API specs, or runbooks are affected by these CI-only changes.

---

### **Unit Tests Added or Updated** (Yes / No)
**No.** Pipeline YAML configuration changes are not covered by extension unit tests.

---

### **Additional Testing Performed**
- Verified template usage: both `azure-pipelines.yml` and `release-pipeline.yml` consume `common-steps.yml`; only the release pipeline passes `signExtension: true`, so CI defaults to `false` (no signing) and release signs.
- Confirmed the signature file (`extension.signature.p7s`) is still produced by the `Prepare Manifest Signature` step, so downstream `CopyFiles` staging does not fail in CI.

---

### **Logging Added/Updated** (Yes/No)
**No.**

---

### **Telemetry Added/Updated** (Yes/No)
**No.**

---

### **Rollback Scenario and Process** (Yes/No)
**Yes.** Fully revertible by reverting this PR:
- Restore the CI trigger to run on `main`.
- Restore the original unconditional `Sign Extension` step (and remove `signExtension: true` from the release pipeline) to return to always-on signing.
No state migration or data changes are involved.

---

### **Dependency Impact Assessed and Regression Tested** (Yes/No)
**Yes.** The only shared dependency is `common-steps.yml`. The release pipeline explicitly opts in with `signExtension: true`, preserving its signed, publishable VSIX; only the CI pipeline changes to unsigned. No product modules, APIs, or third-party libraries are affected.
